### PR TITLE
Contextual info to error messages

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -52,7 +52,7 @@ func Process(prefix string, spec interface{}) error {
 				if err != nil {
 					return &ParseError{
 						KeyName:   key,
-						FieldName: s.Type().String() + "." + fieldName,
+						FieldName: fieldName,
 						TypeName:  f.Type().String(),
 						Value:     value,
 					}
@@ -63,7 +63,7 @@ func Process(prefix string, spec interface{}) error {
 				if err != nil {
 					return &ParseError{
 						KeyName:   key,
-						FieldName: s.Type().String() + "." + fieldName,
+						FieldName: fieldName,
 						TypeName:  f.Type().String(),
 						Value:     value,
 					}
@@ -74,7 +74,7 @@ func Process(prefix string, spec interface{}) error {
 				if err != nil {
 					return &ParseError{
 						KeyName:   key,
-						FieldName: s.Type().String() + "." + fieldName,
+						FieldName: fieldName,
 						TypeName:  f.Type().String(),
 						Value:     value,
 					}


### PR DESCRIPTION
I wanted to see what would show up as an error message if an invalid value was given to a `time.Duration` field.

``` go
type Conf struct {
    // ...
    HeartBeat  time.Duration
    // ...
}
```

``` bash
$ APP_HEARTBEAT="vjhgfhg" go run app.go
envconfig.Process: assigning to HeartBeat: converting 'vjhgfhg' to an int64
```

I thought this error could be made better, more specific. Especially, for the reader of the error message, it's not clear that `APP_HEARTBEAT` suddenly became `HeartBeat`, and that `int64` in fact means `time.Duration`.

I came up with this:

``` bash
$ APP_HEARTBEAT="vjhgfhg" go run app.go
envconfig.Process: assigning APP_HEARTBEAT to HeartBeat: converting 'vjhgfhg' to type time.Duration
```

I find the extra information useful.  However I'm not sure that's the best/less ambiguous way.
