### PR TITLE
[Feature] Custom Decoders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: go
 
 go:
   - 1.1
+  - 1.2
+  - 1.3
   - tip

--- a/envconfig.go
+++ b/envconfig.go
@@ -30,9 +30,9 @@ type ParseError struct {
 
 func (e *ParseError) Error() string {
 	if e.DecoderErr != nil {
-		return fmt.Sprintf("envconfig.Process: processing %[1]s for %[2]s: error in custom decoder: %[3]s", e.KeyName, e.FieldName, e.DecoderErr)
+		return fmt.Sprintf("envconfig.Process: processing %s for %s: error in custom decoder: %s", e.KeyName, e.FieldName, e.DecoderErr)
 	}
-	return fmt.Sprintf("envconfig.Process: assigning %[1]s to %[2]s: converting '%[3]s' to type %[4]s", e.KeyName, e.FieldName, e.Value, e.TypeName)
+	return fmt.Sprintf("envconfig.Process: assigning %s to %s: converting '%s' to type %s", e.KeyName, e.FieldName, e.Value, e.TypeName)
 }
 
 func Process(prefix string, spec interface{}) error {

--- a/envconfig.go
+++ b/envconfig.go
@@ -121,4 +121,3 @@ func RegisterDecoder(fieldName string, f func(envValue string, fieldValue, struc
 func ClearDecoders() {
 	CustomDecoders = make(map[string]func(string, reflect.Value, reflect.Value) error)
 }
-

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -5,19 +5,19 @@
 package envconfig
 
 import (
+	"errors"
 	"os"
-	"testing"
 	"reflect"
 	"strings"
-	"errors"
+	"testing"
 )
 
 type Specification struct {
-	Debug bool
-	Port  int
-	Rate  float32
-	User  string
-	Keys  []string
+	Debug                        bool
+	Port                         int
+	Rate                         float32
+	User                         string
+	Keys                         []string
 	MultiWordVar                 string
 	MultiWordVarWithAlt          string `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
 	MultiWordVarWithLowerCaseAlt string `envconfig:"multi_word_var_with_lower_case_alt"`
@@ -108,7 +108,7 @@ func TestErrInvalidSpecification(t *testing.T) {
 }
 
 func TestCustomDecoder(t *testing.T) {
-    var s Specification
+	var s Specification
 	os.Clearenv()
 	os.Setenv("ENV_CONFIG_DEBUG", "true")
 	os.Setenv("ENV_CONFIG_PORT", "8080")

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -7,6 +7,9 @@ package envconfig
 import (
 	"os"
 	"testing"
+	"reflect"
+	"strings"
+	"errors"
 )
 
 type Specification struct {
@@ -14,6 +17,7 @@ type Specification struct {
 	Port  int
 	Rate  float32
 	User  string
+	Keys  []string
 }
 
 func TestProcess(t *testing.T) {
@@ -97,5 +101,67 @@ func TestErrInvalidSpecification(t *testing.T) {
 	err := Process("env_config", &m)
 	if err != ErrInvalidSpecification {
 		t.Errorf("expected %v, got %v", ErrInvalidSpecification, err)
+	}
+}
+
+func TestCustomDecoder(t *testing.T) {
+    var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_DEBUG", "true")
+	os.Setenv("ENV_CONFIG_PORT", "8080")
+	os.Setenv("ENV_CONFIG_RATE", "0.5")
+	os.Setenv("ENV_CONFIG_USER", "Kelsey")
+	os.Setenv("ENV_CONFIG_KEYS", "a,b,c")
+
+	RegisterDecoder("Keys", func(value string, fieldValue, struc reflect.Value) error {
+		items := strings.Split(value, ",")
+		n := len(items)
+
+		if fieldValue.Len() < n {
+			fieldValue.Set(reflect.MakeSlice(fieldValue.Type(), n, n))
+		}
+
+		for i, v := range items {
+			fieldValue.Index(i).SetString(v)
+		}
+
+		return nil
+	})
+
+	err := Process("env_config", &s)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if !s.Debug {
+		t.Errorf("expected %v, got %v", true, s.Debug)
+	}
+	if s.Port != 8080 {
+		t.Errorf("expected %d, got %v", 8080, s.Port)
+	}
+	if s.Rate != 0.5 {
+		t.Errorf("expected %f, got %v", 0.5, s.Rate)
+	}
+	if s.User != "Kelsey" {
+		t.Errorf("expected %s, got %s", "Kelsey", s.User)
+	}
+	for i, v := range []string{"a", "b", "c"} {
+		if s.Keys[i] != v {
+			t.Errorf("expected %s go %s", v, s.Keys[i])
+		}
+	}
+}
+
+func TestCustomDecoderError(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_KEYS", "a,b,c")
+
+	RegisterDecoder("Keys", func(value string, fieldValue, struc reflect.Value) error {
+		return errors.New("!")
+	})
+
+	err := Process("env_config", &s)
+	if err.Error() != "envconfig.Process: processing ENV_CONFIG_KEYS for Keys: error in custom decoder: !" {
+		t.Errorf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
So I needed to implement an additional config provider for my app via env vars and stumbled across this short and sweet library, but I needed a little extra in the form of custom decoding of the env var value itself (think slices of data or even references to other env vars).

In my particular case I had a variable number of hashes I needed to get into my app as a single struct field and couldn't find a way to do it easily with the current code base so I extended it with the concept of custom decoders.

Effectively you register a decoder for a field name before you call `Process()`, you can register as many decoders as you like and you can also clear them out once you finish (as the storage mechanism is a package level var):

```Go
     type Config struct {
         Keys []string
     }

     envconfig.RegisterDecoder("Keys", func(value string, fieldValue, struc reflect.Value) error {
         ...logic...
     })
     defer envconfig.ClearDecoders()
```

In this case it is registered to the `Keys` struct field. You are given access to the current env var value, struct field and the struct being operated on. This should allow for maximum flexibility for a custom decoder.

The decoder func could be turned into a named type but I thought it was shorter for the caller to use an anonymous func. This can be changed though.

Thanks,
Adrian