### PR TITLE
Add "envconfig_required_field" struct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,16 @@ export MYAPP_MULTI_WORD_VAR="this will be the value"
 
 # export MYAPP_MULTIWORDVAR="and this will not"
 ```
+
+Envconfig also supports setting a struct tag to mark a field as required.
+
+For example:
+
+```Go
+type Specification struct {
+    Hello string `envconfig_required_field:"true"`
+    Goodbye string
+}
+```
+
+In this example, envconfig.process("app", &Specification{}) will return an error unless the environment variable "APP_HELLO" has been set.

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -20,6 +20,33 @@ type Specification struct {
 	NoPrefixWithAlt              string `envconfig:"SERVICE_HOST"`
 }
 
+type SpecificationWithRequiredFields struct {
+	RequiredString string `envconfig_required_field:"true"`
+	RequiredBool   bool   `envconfig_required_field:"true"`
+	NotRequired    string
+}
+
+func TestProcessRequiredFields(t *testing.T) {
+	os.Clearenv()
+
+	err := Process("env_config", &SpecificationWithRequiredFields{})
+	if !(err != nil && err.(*MissingFieldError).KeyName == "REQUIREDSTRING") {
+		t.Error("envconfig_required_field for string was not enforced")
+	}
+
+	os.Setenv("ENV_CONFIG_REQUIREDSTRING", "Set")
+	err = Process("env_config", &SpecificationWithRequiredFields{})
+	if !(err != nil && err.(*MissingFieldError).KeyName == "REQUIREDBOOL") {
+		t.Error("envconfig_required_field for bool was not enforced")
+	}
+
+	os.Setenv("ENV_CONFIG_REQUIREDBOOL", "true")
+	err = Process("env_config", &SpecificationWithRequiredFields{})
+	if err != nil {
+		t.Error("envconfig_required_field for unrequired field failed")
+	}
+}
+
 func TestProcess(t *testing.T) {
 	var s Specification
 	os.Clearenv()


### PR DESCRIPTION
So that you can enforce that a field has really been set.

Useful for application env config values which are required for execution.