### PR TITLE
added support for envconfig with no prefix if alt tag is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ Whereas before, the value for `MultiWordVar` would have been populated
 with `MYAPP_MULTIWORDVAR`, it will now be populated with
 `MYAPP_MULTI_WORD_VAR`.
 
+If envconfig can't find an environment variable in the form PREFIX_MYVAR, and there
+is a struct tag defined, it will try to populate your variable with an environment
+variable that directly matches the envconfig tag in your struct definition:
+
+```shell
+export SERVICE_HOST=127.0.0.1
+export MYAPP_DEGUB=true
+```
+```Go
+type Specification struct {
+	ServiceHost	`envconfig:"SERVICE_HOST"`
+	Debug bool
+}
+```
+
+
 ```Bash
 export MYAPP_MULTI_WORD_VAR="this will be the value"
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -48,7 +48,11 @@ func Process(prefix string, spec interface{}) error {
 			key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
 			value := os.Getenv(key)
 			if value == "" {
-				continue
+				key := strings.ToUpper(fieldName)
+				value = os.Getenv(key)
+				if value == "" {
+					continue
+				}
 			}
 			switch f.Kind() {
 			case reflect.String:

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -17,6 +17,7 @@ type Specification struct {
 	MultiWordVar                 string
 	MultiWordVarWithAlt          string `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
 	MultiWordVarWithLowerCaseAlt string `envconfig:"multi_word_var_with_lower_case_alt"`
+	NoPrefixWithAlt              string `envconfig:"SERVICE_HOST"`
 }
 
 func TestProcess(t *testing.T) {
@@ -26,9 +27,13 @@ func TestProcess(t *testing.T) {
 	os.Setenv("ENV_CONFIG_PORT", "8080")
 	os.Setenv("ENV_CONFIG_RATE", "0.5")
 	os.Setenv("ENV_CONFIG_USER", "Kelsey")
+	os.Setenv("SERVICE_HOST", "127.0.0.1")
 	err := Process("env_config", &s)
 	if err != nil {
 		t.Error(err.Error())
+	}
+	if s.NoPrefixWithAlt != "127.0.0.1" {
+		t.Errorf("expected %v, got %v", "127.0.0.1", s.NoPrefixWithAlt)
 	}
 	if !s.Debug {
 		t.Errorf("expected %v, got %v", true, s.Debug)


### PR DESCRIPTION
This pull request enables processing environment variables without the typical envconfig prefix if an alt tag exists.  Use case: Kubernetes, where service environment variables will have a variety of prefixes.
