### PR TITLE
Empty prefix

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -45,8 +45,13 @@ func Process(prefix string, spec interface{}) error {
 			} else {
 				fieldName = typeOfSpec.Field(i).Name
 			}
-			key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
-			value := os.Getenv(key)
+			var key string
+			if prefix == "" {
+				key = fieldName
+			} else {
+				key = fmt.Sprintf("%s_%s", prefix, fieldName)
+			}
+			value := os.Getenv(strings.ToUpper(key))
 			if value == "" {
 				continue
 			}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -44,6 +44,31 @@ func TestProcess(t *testing.T) {
 	}
 }
 
+func TestProcessNoPrefix(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("DEBUG", "true")
+	os.Setenv("PORT", "8080")
+	os.Setenv("RATE", "0.5")
+	os.Setenv("USER", "Kelsey")
+	err := Process("", &s)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if !s.Debug {
+		t.Errorf("expected %v, got %v", true, s.Debug)
+	}
+	if s.Port != 8080 {
+		t.Errorf("expected %d, got %v", 8080, s.Port)
+	}
+	if s.Rate != 0.5 {
+		t.Errorf("expected %f, got %v", 0.5, s.Rate)
+	}
+	if s.User != "Kelsey" {
+		t.Errorf("expected %s, got %s", "Kelsey", s.User)
+	}
+}
+
 func TestParseErrorBool(t *testing.T) {
 	var s Specification
 	os.Clearenv()


### PR DESCRIPTION
Hi I am currently working on a story that needs to parse environment variables to env structs, and your library is exactly what i needed! However, the env structs i'm working with, the fields does not always have the same prefix or have prefix at all, so I added this patch to support empty prefix. Hope this is useful for other people as well. 