### PR TITLE
Update envconfig.go

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -79,7 +79,7 @@ func Process(prefix string, spec interface{}) error {
 					}
 				}
 				f.SetBool(boolValue)
-			case reflect.Float32:
+			case reflect.Float32, reflect.Float64:
 				floatValue, err := strconv.ParseFloat(value, f.Type().Bits())
 				if err != nil {
 					return &ParseError{


### PR DESCRIPTION
Adding this type to the case provides support for 64bit floating point fields.