### PR TITLE
More informative error for missing values

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -15,7 +15,6 @@ import (
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
 var ErrInvalidSpecification = errors.New("invalid specification must be a struct")
-var ErrRequiredKey = errors.New("required key missing value")
 
 // A ParseError occurs when an environment variable cannot be converted to
 // the type required by a struct field during assignment.
@@ -59,7 +58,7 @@ func Process(prefix string, spec interface{}) error {
 			req := typeOfSpec.Field(i).Tag.Get("required")
 			if value == "" {
 				if req == "true" {
-					return ErrRequiredKey
+					return fmt.Errorf("required key %s missing value", key)
 				}
 				continue
 			}


### PR DESCRIPTION
It's somewhat difficult to tell which required value is missing when using `required:"true"`.

I know this PR doesn't give the whole picture (it only mentions PREFIX_VAR even when VAR was also checked) but I think it's still friendlier than the existing message.