### PR TITLE
Support processing of embedded structs.

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 )
 
+type SubSpecification struct {
+	SubVar string
+}
+
 type Specification struct {
 	Debug                        bool
 	Port                         int
@@ -22,6 +26,8 @@ type Specification struct {
 	RequiredVar                  string `required:"true"`
 	NoPrefixDefault              string `envconfig:"BROKER" default:"127.0.0.1"`
 	RequiredDefault              string `required:"true" default:"foo2bar"`
+
+	SubSpecification
 }
 
 func TestProcess(t *testing.T) {
@@ -33,6 +39,7 @@ func TestProcess(t *testing.T) {
 	os.Setenv("ENV_CONFIG_USER", "Kelsey")
 	os.Setenv("SERVICE_HOST", "127.0.0.1")
 	os.Setenv("ENV_CONFIG_REQUIREDVAR", "foo")
+	os.Setenv("ENV_CONFIG_SUBVAR", "sub")
 	err := Process("env_config", &s)
 	if err != nil {
 		t.Error(err.Error())
@@ -54,6 +61,9 @@ func TestProcess(t *testing.T) {
 	}
 	if s.RequiredVar != "foo" {
 		t.Errorf("expected %s, got %s", "foo", s.RequiredVar)
+	}
+	if s.SubSpecification.SubVar != "sub" {
+		t.Errorf("expected %s, got %s", "sub", s.SubSpecification.SubVar)
 	}
 }
 


### PR DESCRIPTION
envconfig currently ignores embedded structs in Process. Embedding can be helpful if you want to join together configuration from multiple application subpackages and process in a single shot. This updates envconfig to offer simple support for embedded structs. 

Note that it completely ignores the name and tags on the struct. I'd be happy to implement some semantic here (e.g. using the struct name / tags as an additional prefix) but I wanted to get feedback on the overall approach first.