### PR TITLE
Add support for setting slice values from environment variables

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -67,64 +67,22 @@ func Process(prefix string, spec interface{}) error {
 				continue
 			}
 
-			switch f.Kind() {
-			case reflect.String:
-				f.SetString(value)
-			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-				var (
-					intValue int64
-					err      error
-				)
-				if f.Kind() == reflect.Int64 && f.Type().PkgPath() == "time" && f.Type().Name() == "Duration" {
-					var d time.Duration
-					d, err = time.ParseDuration(value)
-					intValue = int64(d)
-				} else {
-					intValue, err = strconv.ParseInt(value, 0, f.Type().Bits())
-				}
-				if err != nil {
-					return &ParseError{
-						KeyName:   key,
-						FieldName: fieldName,
-						TypeName:  f.Type().String(),
-						Value:     value,
-					}
-				}
-				f.SetInt(intValue)
-			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				uintValue, err := strconv.ParseUint(value, 0, f.Type().Bits())
-				if err != nil {
-					return &ParseError{
-						KeyName:   key,
-						FieldName: fieldName,
-						TypeName:  f.Type().String(),
-						Value:     value,
-					}
-				}
-				f.SetUint(uintValue)
-			case reflect.Bool:
-				boolValue, err := strconv.ParseBool(value)
-				if err != nil {
-					return &ParseError{
-						KeyName:   key,
-						FieldName: fieldName,
-						TypeName:  f.Type().String(),
-						Value:     value,
-					}
-				}
-				f.SetBool(boolValue)
-			case reflect.Float32, reflect.Float64:
-				floatValue, err := strconv.ParseFloat(value, f.Type().Bits())
-				if err != nil {
-					return &ParseError{
-						KeyName:   key,
-						FieldName: fieldName,
-						TypeName:  f.Type().String(),
-						Value:     value,
-					}
-				}
-				f.SetFloat(floatValue)
+			parser := getParser(f.Type(), f.Kind())
+			if parser == nil {
+				continue
 			}
+
+			parsedValue, err := parser.Parse(value)
+			if err != nil {
+				return &ParseError{
+					KeyName:   key,
+					FieldName: fieldName,
+					TypeName:  f.Type().String(),
+					Value:     value,
+				}
+			}
+			parser.Set(&f, parsedValue)
+
 		}
 	}
 	return nil
@@ -134,4 +92,117 @@ func MustProcess(prefix string, spec interface{}) {
 	if err := Process(prefix, spec); err != nil {
 		panic(err)
 	}
+}
+
+// fieldParser represents a parsing function (conversion from string) and a
+// setting function (to set the value using reflection)
+type fieldParser struct {
+	Parse func(v string) (interface{}, error)
+	Set   func(f *reflect.Value, v interface{})
+}
+
+// getParser returns back a FieldParser instance for the given type
+func getParser(t reflect.Type, k reflect.Kind) (parser *fieldParser) {
+	switch k {
+	case reflect.String:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				return v, nil
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.SetString(v.(string))
+			},
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				var intValue int64
+				var err error
+				if k == reflect.Int64 && t.PkgPath() == "time" && t.Name() == "Duration" {
+					var d time.Duration
+					d, err = time.ParseDuration(v)
+					intValue = int64(d)
+				} else {
+					intValue, err = strconv.ParseInt(v, 0, t.Bits())
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				return intValue, nil
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.SetInt(v.(int64))
+			},
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				uintValue, err := strconv.ParseUint(v, 0, t.Bits())
+				if err != nil {
+					return nil, err
+				}
+
+				return uintValue, nil
+
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.SetUint(v.(uint64))
+			},
+		}
+
+	case reflect.Bool:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				boolValue, err := strconv.ParseBool(v)
+				if err != nil {
+					return nil, err
+				}
+				return boolValue, nil
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.SetBool(v.(bool))
+			},
+		}
+
+	case reflect.Float32, reflect.Float64:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				floatValue, err := strconv.ParseFloat(v, t.Bits())
+				if err != nil {
+					return nil, err
+				}
+				return floatValue, nil
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.SetFloat(v.(float64))
+			},
+		}
+	case reflect.Slice:
+		parser = &fieldParser{
+			Parse: func(v string) (interface{}, error) {
+				elemType := t.Elem()
+				parser := getParser(elemType, elemType.Kind())
+				strValues := strings.Split(v, ",")
+
+				slice := reflect.MakeSlice(reflect.SliceOf(elemType), 0, 0)
+				for i := range strValues {
+					value, err := parser.Parse(strValues[i])
+					if err != nil {
+						return nil, err
+					}
+
+					itmValue := reflect.ValueOf(value)
+					itmValue = itmValue.Convert(elemType)
+
+					slice = reflect.Append(slice, itmValue)
+				}
+				return slice.Interface(), nil
+			},
+			Set: func(f *reflect.Value, v interface{}) {
+				f.Set(reflect.ValueOf(v))
+			},
+		}
+	}
+	return
 }

--- a/envconfig.go
+++ b/envconfig.go
@@ -30,6 +30,7 @@ func (e *ParseError) Error() string {
 	return fmt.Sprintf("envconfig.Process: assigning %[1]s to %[2]s: converting '%[3]s' to type %[4]s", e.KeyName, e.FieldName, e.Value, e.TypeName)
 }
 
+// Process populates the specified struct based on environment variables
 func Process(prefix string, spec interface{}) error {
 	s := reflect.ValueOf(spec).Elem()
 	if s.Kind() != reflect.Struct {
@@ -88,6 +89,7 @@ func Process(prefix string, spec interface{}) error {
 	return nil
 }
 
+// MustProcess is the same as Process but panics if an error occurs
 func MustProcess(prefix string, spec interface{}) {
 	if err := Process(prefix, spec); err != nil {
 		panic(err)

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -15,7 +15,7 @@ type Specification struct {
 	Port                         int
 	Rate                         float32
 	User                         string
-	Ttl                          uint32
+	TTL                          uint32
 	Timeout                      time.Duration
 	AdminUsers                   []string
 	MagicNumbers                 []int
@@ -58,8 +58,8 @@ func TestProcess(t *testing.T) {
 	if s.Rate != 0.5 {
 		t.Errorf("expected %f, got %v", 0.5, s.Rate)
 	}
-	if s.Ttl != 30 {
-		t.Errorf("expected %d, got %v", 30, s.Ttl)
+	if s.TTL != 30 {
+		t.Errorf("expected %d, got %v", 30, s.TTL)
 	}
 	if s.User != "Kelsey" {
 		t.Errorf("expected %s, got %s", "Kelsey", s.User)
@@ -147,11 +147,11 @@ func TestParseErrorUint(t *testing.T) {
 	if !ok {
 		t.Errorf("expected ParseError, got %v", v)
 	}
-	if v.FieldName != "Ttl" {
-		t.Errorf("expected %s, got %v", "Ttl", v.FieldName)
+	if v.FieldName != "TTL" {
+		t.Errorf("expected %s, got %v", "TTL", v.FieldName)
 	}
-	if s.Ttl != 0 {
-		t.Errorf("expected %v, got %v", 0, s.Ttl)
+	if s.TTL != 0 {
+		t.Errorf("expected %v, got %v", 0, s.TTL)
 	}
 }
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -17,6 +17,8 @@ type Specification struct {
 	User                         string
 	Ttl                          uint32
 	Timeout                      time.Duration
+	AdminUsers                   []string
+	MagicNumbers                 []int
 	MultiWordVar                 string
 	MultiWordVarWithAlt          string `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
 	MultiWordVarWithLowerCaseAlt string `envconfig:"multi_word_var_with_lower_case_alt"`
@@ -35,6 +37,8 @@ func TestProcess(t *testing.T) {
 	os.Setenv("ENV_CONFIG_RATE", "0.5")
 	os.Setenv("ENV_CONFIG_USER", "Kelsey")
 	os.Setenv("ENV_CONFIG_TIMEOUT", "2m")
+	os.Setenv("ENV_CONFIG_ADMINUSERS", "John,Adam,Will")
+	os.Setenv("ENV_CONFIG_MAGICNUMBERS", "5,10,20")
 	os.Setenv("SERVICE_HOST", "127.0.0.1")
 	os.Setenv("ENV_CONFIG_TTL", "30")
 	os.Setenv("ENV_CONFIG_REQUIREDVAR", "foo")
@@ -65,6 +69,18 @@ func TestProcess(t *testing.T) {
 	}
 	if s.RequiredVar != "foo" {
 		t.Errorf("expected %s, got %s", "foo", s.RequiredVar)
+	}
+	if len(s.AdminUsers) != 3 ||
+		s.AdminUsers[0] != "John" ||
+		s.AdminUsers[1] != "Adam" ||
+		s.AdminUsers[2] != "Will" {
+		t.Errorf("expected %s, got %s", []string{"John", "Adam", "Will"}, s.AdminUsers)
+	}
+	if len(s.MagicNumbers) != 3 ||
+		s.MagicNumbers[0] != 5 ||
+		s.MagicNumbers[1] != 10 ||
+		s.MagicNumbers[2] != 20 {
+		t.Errorf("expected %d, got %d", []int{5, 10, 20}, s.MagicNumbers)
 	}
 }
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -74,13 +74,13 @@ func TestProcess(t *testing.T) {
 		s.AdminUsers[0] != "John" ||
 		s.AdminUsers[1] != "Adam" ||
 		s.AdminUsers[2] != "Will" {
-		t.Errorf("expected %s, got %s", []string{"John", "Adam", "Will"}, s.AdminUsers)
+		t.Errorf("expected %#v, got %#v", []string{"John", "Adam", "Will"}, s.AdminUsers)
 	}
 	if len(s.MagicNumbers) != 3 ||
 		s.MagicNumbers[0] != 5 ||
 		s.MagicNumbers[1] != 10 ||
 		s.MagicNumbers[2] != 20 {
-		t.Errorf("expected %d, got %d", []int{5, 10, 20}, s.MagicNumbers)
+		t.Errorf("expected %#v, got %#v", []int{5, 10, 20}, s.MagicNumbers)
 	}
 }
 


### PR DESCRIPTION
Fixes #31 by adding support for populating slices from comma separated environment variables.

```
type Specification struct {
	AdminUsers                   []string
	MagicNumbers                 []int
```

To support this, I split out the switch statement from `Process()` into `Parse()` and `Set()` functions which deal with deserializing values from a specific type and setting the values using reflection (respectively). This was done primarily to allow for reuse of the existing string conversion logic for each type with slices containing those types.

Tests included