### PR TITLE
Fixed missing error word in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,
 it will populate it with "foobar" as a default value.
 
 If envconfig can't find an environment variable value for `MYAPP_REQUIREDVAR`,
-it will return an when asked to process the struct.
+it will return an error when asked to process the struct.
 
 If envconfig can't find an environment variable in the form `PREFIX_MYVAR`, and there
 is a struct tag defined, it will try to populate your variable with an environment


### PR DESCRIPTION
## What does this PR solves?
There was a missing `error` word in README.md that made it harder to understand the required struct tag.

## What is the solution?
Fixed it by adding it.

## How should this be manually tested?
Read the README.md.

## Risk
None, just added a missing word.