### PR TITLE
Added support for nested structs.

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -83,7 +83,13 @@ func processField(field reflect.Value, spec reflect.StructField, prefix string) 
 	if alt != "" {
 		fieldName = alt
 	}
-	key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
+
+	var key string
+	if spec.Anonymous && alt == "" {
+		key = strings.ToUpper(prefix)
+	} else {
+		key = strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
+	}
 
 	switch field.Kind() {
 	case reflect.Struct:

--- a/envconfig.go
+++ b/envconfig.go
@@ -47,14 +47,14 @@ func Process(prefix string, spec interface{}) error {
 	if s.Kind() != reflect.Struct {
 		return ErrInvalidSpecification
 	}
-	typeOfSpec := s.Type()
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
-		if !f.CanSet() || typeOfSpec.Field(i).Tag.Get("ignored") == "true" {
+		fSpec := s.Type().Field(i)
+		if !f.CanSet() || fSpec.Tag.Get("ignored") == "true" {
 			continue
 		}
 
-		if typeOfSpec.Field(i).Anonymous && f.Kind() == reflect.Struct {
+		if fSpec.Anonymous && f.Kind() == reflect.Struct {
 			embeddedPtr := f.Addr().Interface()
 			if err := Process(prefix, embeddedPtr); err != nil {
 				return err
@@ -62,42 +62,8 @@ func Process(prefix string, spec interface{}) error {
 			f.Set(reflect.ValueOf(embeddedPtr).Elem())
 		}
 
-		alt := typeOfSpec.Field(i).Tag.Get("envconfig")
-		fieldName := typeOfSpec.Field(i).Name
-		if alt != "" {
-			fieldName = alt
-		}
-		key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
-		// `os.Getenv` cannot differentiate between an explicitly set empty value
-		// and an unset value. `os.LookupEnv` is preferred to `syscall.Getenv`,
-		// but it is only available in go1.5 or newer.
-		value, ok := syscall.Getenv(key)
-		if !ok && alt != "" {
-			key := strings.ToUpper(fieldName)
-			value, ok = syscall.Getenv(key)
-		}
-
-		def := typeOfSpec.Field(i).Tag.Get("default")
-		if def != "" && !ok {
-			value = def
-		}
-
-		req := typeOfSpec.Field(i).Tag.Get("required")
-		if !ok && def == "" {
-			if req == "true" {
-				return fmt.Errorf("required key %s missing value", key)
-			}
-			continue
-		}
-
-		err := processField(value, f)
-		if err != nil {
-			return &ParseError{
-				KeyName:   key,
-				FieldName: fieldName,
-				TypeName:  f.Type().String(),
-				Value:     value,
-			}
+		if err := processField(f, fSpec, prefix); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -110,13 +76,78 @@ func MustProcess(prefix string, spec interface{}) {
 	}
 }
 
-func processField(value string, field reflect.Value) error {
-	typ := field.Type()
+// processField processes a field using the given spec/prefix.
+func processField(field reflect.Value, spec reflect.StructField, prefix string) error {
+	alt := spec.Tag.Get("envconfig")
+	fieldName := spec.Name
+	if alt != "" {
+		fieldName = alt
+	}
+	key := strings.ToUpper(fmt.Sprintf("%s_%s", prefix, fieldName))
 
-	decoder := decoderFrom(field)
-	if decoder != nil {
+	switch field.Kind() {
+	case reflect.Struct:
+		return Process(key, field.Addr().Interface())
+	case reflect.Ptr:
+		fieldType := spec.Type.Elem()
+		if fieldType.Kind() != reflect.Struct {
+			break
+		}
+
+		if field.IsNil() {
+			fieldValue := reflect.New(fieldType)
+			err := Process(key, fieldValue.Interface())
+
+			if fieldValue.IsValid() {
+				field.Set(fieldValue)
+			}
+
+			return err
+		}
+
+		return Process(key, field.Interface())
+	}
+
+	// `os.Getenv` cannot differentiate between an explicitly set empty value
+	// and an unset value. `os.LookupEnv` is preferred to `syscall.Getenv`,
+	// but it is only available in go1.5 or newer.
+	value, ok := syscall.Getenv(key)
+	if !ok && alt != "" {
+		key := strings.ToUpper(fieldName)
+		value, ok = syscall.Getenv(key)
+	}
+
+	def := spec.Tag.Get("default")
+	if def != "" && !ok {
+		value = def
+	}
+
+	req := spec.Tag.Get("required")
+	if !ok && def == "" {
+		if req == "true" {
+			return fmt.Errorf("required key %s missing value", key)
+		}
+		return nil
+	}
+
+	if err := processFieldValue(field, value); err != nil {
+		return &ParseError{
+			KeyName:   key,
+			FieldName: fieldName,
+			TypeName:  field.Type().String(),
+			Value:     value,
+		}
+	}
+	return nil
+}
+
+// processFieldValue processes a field using the given value.
+func processFieldValue(field reflect.Value, value string) error {
+	if decoder := decoderFrom(field); decoder != nil {
 		return decoder.Decode(value)
 	}
+
+	typ := field.Type()
 
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
@@ -168,7 +199,7 @@ func processField(value string, field reflect.Value) error {
 		vals := strings.Split(value, ",")
 		sl := reflect.MakeSlice(typ, len(vals), len(vals))
 		for i, val := range vals {
-			err := processField(val, sl.Index(i))
+			err := processFieldValue(sl.Index(i), val)
 			if err != nil {
 				return err
 			}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -441,6 +441,24 @@ func TestEmbeddedButIgnoredStruct(t *testing.T) {
 	}
 }
 
+func TestEmbeddedValueStruct(t *testing.T) {
+	var s struct {
+		Timeout struct {
+			time.Duration
+		}
+	}
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_TIMEOUT", "5s")
+
+	if err := Process("env_config", &s); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Timeout.String() != "5s" {
+		t.Errorf("expected %s, got %s", "5s", s.Timeout)
+	}
+}
+
 func TestNestedStruct(t *testing.T) {
 	var s Specification
 	os.Clearenv()

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -32,6 +32,8 @@ type Specification struct {
 	NoPrefixDefault              string  `envconfig:"BROKER" default:"127.0.0.1"`
 	RequiredDefault              string  `required:"true" default:"foo2bar"`
 	Ignored                      string  `ignored:"true"`
+	Nested                       Nested
+	NestedPointer                *Nested
 }
 
 type Embedded struct {
@@ -46,6 +48,22 @@ type Embedded struct {
 type EmbeddedButIgnored struct {
 	FirstEmbeddedButIgnored  string
 	SecondEmbeddedButIgnored string
+}
+
+type Nested struct {
+	Child struct {
+		Body    string
+		Enabled bool
+		Ignored string `ignored:"true"`
+	}
+	ChildAlt struct {
+		BodyAlt    string `envconfig:"body"`
+		EnabledAlt bool   `envconfig:"enabled"`
+		Ignored    string `ignored:"true"`
+	} `envconfig:"child_alt"`
+	Body    string
+	Enabled bool
+	Ignored string `ignored:"true"`
 }
 
 func TestProcess(t *testing.T) {
@@ -420,6 +438,85 @@ func TestEmbeddedButIgnoredStruct(t *testing.T) {
 	}
 	if s.SecondEmbeddedButIgnored != "" {
 		t.Errorf("expected empty string, got %#v", s.Ignored)
+	}
+}
+
+func TestNestedStruct(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
+	os.Setenv("ENV_CONFIG_NESTED_BODY", "body1")
+	os.Setenv("ENV_CONFIG_NESTED_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTED_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_BODY", "body2")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_ALT_BODY", "body3")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_ALT_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTED_CHILD_ALT_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_BODY", "body1")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_BODY", "body2")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_ALT_BODY", "body3")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_ALT_ENABLED", "true")
+	os.Setenv("ENV_CONFIG_NESTEDPOINTER_CHILD_ALT_IGNORED", "was-not-ignored")
+
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+	if !s.Nested.Enabled {
+		t.Errorf("expected %v, got %v", true, s.Nested.Enabled)
+	}
+	if s.Nested.Ignored != "" {
+		t.Errorf("expected empty string, got %#v", s.Nested.Ignored)
+	}
+	if s.Nested.Body != "body1" {
+		t.Errorf("expected %s, got %s", "body1", s.Nested.Body)
+	}
+	if !s.Nested.Child.Enabled {
+		t.Errorf("expected %v, got %v", true, s.Nested.Child.Enabled)
+	}
+	if s.Nested.Child.Ignored != "" {
+		t.Errorf("expected empty string, got %#v", s.Nested.Child.Ignored)
+	}
+	if s.Nested.Child.Body != "body2" {
+		t.Errorf("expected %s, got %s", "body2", s.Nested.Child.Body)
+	}
+	if !s.Nested.ChildAlt.EnabledAlt {
+		t.Errorf("expected %v, got %v", true, s.Nested.ChildAlt.EnabledAlt)
+	}
+	if s.Nested.ChildAlt.Ignored != "" {
+		t.Errorf("expected empty string, got %#v", s.Nested.ChildAlt.Ignored)
+	}
+	if s.Nested.ChildAlt.BodyAlt != "body3" {
+		t.Errorf("expected %s, got %s", "body3", s.Nested.ChildAlt.BodyAlt)
+	}
+	if s.NestedPointer == nil {
+		t.Fatalf("expected non-nil pointer")
+	}
+	if !s.NestedPointer.Enabled {
+		t.Errorf("expected %v, got %v", true, s.NestedPointer.Enabled)
+	}
+	if s.NestedPointer.Ignored != "" {
+		t.Errorf("expected empty string, got %#v", s.NestedPointer.Ignored)
+	}
+	if s.NestedPointer.Body != "body1" {
+		t.Errorf("expected %s, got %s", "body1", s.NestedPointer.Body)
+	}
+	if !s.NestedPointer.Child.Enabled {
+		t.Errorf("expected %v, got %v", true, s.NestedPointer.Child.Enabled)
+	}
+	if s.NestedPointer.Child.Body != "body2" {
+		t.Errorf("expected %s, got %s", "body2", s.NestedPointer.Child.Body)
+	}
+	if !s.NestedPointer.ChildAlt.EnabledAlt {
+		t.Errorf("expected %v, got %v", true, s.NestedPointer.ChildAlt.EnabledAlt)
+	}
+	if s.NestedPointer.ChildAlt.BodyAlt != "body3" {
+		t.Errorf("expected %s, got %s", "body3", s.NestedPointer.ChildAlt.BodyAlt)
 	}
 }
 


### PR DESCRIPTION
Implements #36.

Small caveat: fields which point to structs will always be non-nil after `envconfig.Process`, even if no values were set.

I didn’t see an effective way to avoid this without introducing a processing context to keep track of fields that were set with non-empty values. Implementing this would not be very difficult, but I wanted to match the existing code base as much as possible at first pass.