### PR TITLE
Do not restrict to embedded anonymous structs

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -54,12 +54,13 @@ func Process(prefix string, spec interface{}) error {
 			continue
 		}
 
-		if typeOfSpec.Field(i).Anonymous && f.Kind() == reflect.Struct {
+		if f.Kind() == reflect.Struct {
 			embeddedPtr := f.Addr().Interface()
 			if err := Process(prefix, embeddedPtr); err != nil {
 				return err
 			}
 			f.Set(reflect.ValueOf(embeddedPtr).Elem())
+			continue
 		}
 
 		alt := typeOfSpec.Field(i).Tag.Get("envconfig")

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Specification struct {
-	Embedded
+	Embedded                     // anonymous
+	EmbeddedNamed                Embedded
 	EmbeddedButIgnored           `ignored:"true"`
 	Debug                        bool
 	Port                         int


### PR DESCRIPTION
There is no real need to restrict to only anonymous structs. This change allows for named structs to be processed as well.