### PR TITLE
Support Struct fields

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -73,7 +73,7 @@ func Process(prefix string, spec interface{}) error {
 		// but it is only available in go1.5 or newer.
 		value, ok := syscall.Getenv(key)
 		if !ok && alt != "" {
-			key := strings.ToUpper(fieldName)
+			key = strings.ToUpper(fieldName)
 			value, ok = syscall.Getenv(key)
 		}
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -53,7 +53,9 @@ type EmbeddedButIgnored struct {
 }
 
 type StructField struct {
-	Name string
+	Name        string
+	WithDefault string `default:"default-value"`
+	WithAltName string `envconfig:"SUB_STRUCT_FIELD_WITH_ALT"`
 }
 
 type StructFieldRecursive struct {
@@ -442,11 +444,19 @@ func TestStructField(t *testing.T) {
 	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
 	os.Setenv("ENV_CONFIG_STRUCTFIELD", "true")
 	os.Setenv("ENV_CONFIG_STRUCTFIELD_NAME", "name-set")
+	os.Setenv("ENV_CONFIG_STRUCTFIELD_SUB_STRUCT_FIELD_WITH_ALT", "name-set")
+
 	if err := Process("env_config", &s); err != nil {
 		t.Error(err.Error())
 	}
 	if s.StructField.Name != "name-set" {
 		t.Errorf("expected struct field name to be set to name-set, got %v", s.StructField.Name)
+	}
+	if s.StructField.WithDefault != "default-value" {
+		t.Errorf("expected struct field name with default value  to be set to default-value, got %v", s.StructField.WithDefault)
+	}
+	if s.StructField.WithAltName != "name-set" {
+		t.Errorf("expected struct field name with alt name to be set to name-set, got %v", s.StructField.WithAltName)
 	}
 }
 
@@ -456,6 +466,7 @@ func TestStructFieldWithAlt(t *testing.T) {
 	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
 	os.Setenv("ENV_CONFIG_STRUCT_FIELD_WITH_ALT", "test")
 	os.Setenv("ENV_CONFIG_STRUCT_FIELD_WITH_ALT_NAME", "name-set")
+	os.Setenv("ENV_CONFIG_STRUCT_FIELD_WITH_ALT_SUB_STRUCT_FIELD_WITH_ALT", "name-set")
 	if err := Process("env_config", &s); err != nil {
 		t.Error(err.Error())
 	}
@@ -463,7 +474,13 @@ func TestStructFieldWithAlt(t *testing.T) {
 		t.Errorf("expected struct field with alt ptr to be non-nil")
 	}
 	if s.StructFieldWithAlt.Name != "name-set" {
-		t.Errorf("expected struct field with alt name to be set to name-set, got %v", s.StructField.Name)
+		t.Errorf("expected struct field with alt name to be set to name-set, got %v", s.StructFieldWithAlt.Name)
+	}
+	if s.StructFieldWithAlt.WithDefault != "default-value" {
+		t.Errorf("expected struct field name with default value  to be set to default-value, got %v", s.StructFieldWithAlt.WithDefault)
+	}
+	if s.StructFieldWithAlt.WithAltName != "name-set" {
+		t.Errorf("expected struct field name with alt name to be set to name-set, got %v", s.StructFieldWithAlt.WithAltName)
 	}
 }
 
@@ -473,14 +490,35 @@ func TestStructFieldWithAltNoPrefix(t *testing.T) {
 	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
 	os.Setenv("STRUCT_FIELD_WITH_ALT", "test")
 	os.Setenv("STRUCT_FIELD_WITH_ALT_NAME", "name-set")
+	os.Setenv("STRUCT_FIELD_WITH_ALT_SUB_STRUCT_FIELD_WITH_ALT", "name-set")
 	if err := Process("env_config", &s); err != nil {
 		t.Error(err.Error())
 	}
 	if s.StructFieldWithAlt == nil {
 		t.Errorf("expected struct field with alt ptr to be non-nil")
 	}
-	if s.StructFieldWithAlt.Name != "name-set" {
-		t.Errorf("expected struct field with alt name to be set to name-set, got %v", s.StructField.Name)
+	if s.StructFieldWithAlt.WithDefault != "default-value" {
+		t.Errorf("expected struct field name with default value  to be set to default-value, got %v", s.StructFieldWithAlt.WithDefault)
+	}
+	if s.StructFieldWithAlt.WithAltName != "name-set" {
+		t.Errorf("expected struct field name with alt name to be set to name-set, got %v", s.StructFieldWithAlt.WithAltName)
+	}
+}
+
+func TestStructFieldWithAltNoPrefixOnSubField(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
+	os.Setenv("STRUCT_FIELD_WITH_ALT", "test")
+	os.Setenv("SUB_STRUCT_FIELD_WITH_ALT", "name-set")
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+	if s.StructFieldWithAlt == nil {
+		t.Errorf("expected struct field with alt ptr to be non-nil")
+	}
+	if s.StructFieldWithAlt.WithAltName != "name-set" {
+		t.Errorf("expected struct field name with alt name to be set to name-set, got %v", s.StructFieldWithAlt.WithAltName)
 	}
 }
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -35,6 +35,7 @@ type Specification struct {
 	StructField                  StructField
 	StructFieldPtr               *StructField
 	StructFieldRecursive         *StructFieldRecursive
+	StructFieldWithAlt           *StructField `envconfig:"STRUCT_FIELD_WITH_ALT"`
 }
 
 type Embedded struct {
@@ -446,6 +447,40 @@ func TestStructField(t *testing.T) {
 	}
 	if s.StructField.Name != "name-set" {
 		t.Errorf("expected struct field name to be set to name-set, got %v", s.StructField.Name)
+	}
+}
+
+func TestStructFieldWithAlt(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
+	os.Setenv("ENV_CONFIG_STRUCT_FIELD_WITH_ALT", "test")
+	os.Setenv("ENV_CONFIG_STRUCT_FIELD_WITH_ALT_NAME", "name-set")
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+	if s.StructFieldWithAlt == nil {
+		t.Errorf("expected struct field with alt ptr to be non-nil")
+	}
+	if s.StructFieldWithAlt.Name != "name-set" {
+		t.Errorf("expected struct field with alt name to be set to name-set, got %v", s.StructField.Name)
+	}
+}
+
+func TestStructFieldWithAltNoPrefix(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "required")
+	os.Setenv("STRUCT_FIELD_WITH_ALT", "test")
+	os.Setenv("STRUCT_FIELD_WITH_ALT_NAME", "name-set")
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+	if s.StructFieldWithAlt == nil {
+		t.Errorf("expected struct field with alt ptr to be non-nil")
+	}
+	if s.StructFieldWithAlt.Name != "name-set" {
+		t.Errorf("expected struct field with alt name to be set to name-set, got %v", s.StructField.Name)
 	}
 }
 


### PR DESCRIPTION
Implements #36 

This pull request proposes a way to allow for struct fields without falling into the trap of recursive types.

If you simply have it recursively call "Process" for sub-structs, if someone makes a recursive type (such as a linked list) it will of course cause a SO.

My proposed solution is to require the user set a non empty string value to the name of the struct field if you intend to provide values for the struct.

This follows fairly naturally with the structure of a YAML file and many other config formats:

```yaml
normalfield: value
connection:
  username: guest
  url: localhost:1234
```

In YAML Becomes in the ENV:

```sh
export MYAPP_NORMALFIELD=value
export MYAPP_CONNECTION=x
export MYAPP_CONNECTION_USERNAME=guest
export MYAPP_CONNECTION_URL=localhost:1234
```

Although it's a bit clunky to have to put "x" or "true" or another value there, that can be fixed if it's ever decided to go to "LookupEnv".

The side-benefit of this method is that it will naturally work with the current code (as the code looks for a value for a field before it attempts to process the field). That value is then passed to processField. 

The struct field will still follow the existing pattern which will first attempts to find a custom decoder before falling into the new code, so this shouldn't be a breaking change for those who have worked around this with a custom decoder.

Our use case for configuring our services, which I believe is not unique, is that each component we develop has its own "Config" type. When we develop a new service which utilizes that component we will add the components config type as a field in the service's "root" config type.

Example:

```go
type serviceConfig struct {
     NumberOfThings string // Some regular top level config for the service
     Rabbit         *bus.RabbitMQ // Rabbit MQ Bus Component Config
}
```