### PR TITLE
issue #45 convert to a two phase approach and add usage capability

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -22,7 +22,7 @@ func (h *HonorDecodeInStruct) Decode(env string) error {
 }
 
 type Specification struct {
-	Embedded
+	Embedded                     `desc:"can we document a struct"`
 	EmbeddedButIgnored           `ignored:"true"`
 	Debug                        bool
 	Port                         int
@@ -34,8 +34,8 @@ type Specification struct {
 	MagicNumbers                 []int
 	MultiWordVar                 string
 	SomePointer                  *string
-	SomePointerWithDefault       *string `default:"foo2baz"`
-	MultiWordVarWithAlt          string  `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
+	SomePointerWithDefault       *string `default:"foo2baz" desc:"foorbar is the word"`
+	MultiWordVarWithAlt          string  `envconfig:"MULTI_WORD_VAR_WITH_ALT" desc:"what alt"`
 	MultiWordVarWithLowerCaseAlt string  `envconfig:"multi_word_var_with_lower_case_alt"`
 	NoPrefixWithAlt              string  `envconfig:"SERVICE_HOST"`
 	DefaultVar                   string  `default:"foobar"`
@@ -53,7 +53,7 @@ type Specification struct {
 }
 
 type Embedded struct {
-	Enabled             bool
+	Enabled             bool `desc:"some embedded value"`
 	EmbeddedPort        int
 	MultiWordVar        string
 	MultiWordVarWithAlt string `envconfig:"MULTI_WITH_DIFFERENT_ALT"`

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2016 Kelsey Hightower and others. All rights reserved.
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file.
+
+package envconfig
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+)
+
+const (
+	// NoHeader constant to use for no header on usage output
+	NoHeader = ""
+
+	// DefaultHeader constant to use for default header on usage output
+	DefaultHeader = `USAGE: {{ . }}
+  This application is configured via the environment. The following environment
+  variables can used specified:
+
+`
+	// DefaultListFormat constant to use to display usage in a list format
+	DefaultListFormat = `  {{.Key}}
+    [description] {{.Description}}
+    [type]        {{.Type}}
+    [default]     {{.Default}}
+    [required]    {{.Required}}`
+
+	// DefaultTableFormat constant to use to display usage in a tabluar format
+	DefaultTableFormat = "table  {{.Key}}\t{{.Type}}\t{{.Default}}\t{{.Required}}\t{{.Description}}"
+)
+
+// usageInfo used to provide values for tabular output to the template function
+type usageInfo struct {
+	Key         string
+	Description string
+	Type        string
+	Default     string
+	Required    string
+}
+
+// toTypeDescription convert techie type information into something more human
+func toTypeDescription(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Array, reflect.Slice:
+		return fmt.Sprintf("List of %s", toTypeDescription(t.Elem()))
+	case reflect.Ptr:
+		return fmt.Sprintf("Reference to %s", toTypeDescription(t.Elem()))
+	case reflect.Chan:
+		return fmt.Sprintf("Channel of %s", toTypeDescription(t.Elem()))
+	case reflect.Map:
+		return fmt.Sprintf("Map of %s to %s", toTypeDescription(t.Key()), toTypeDescription(t.Elem()))
+	case reflect.Func:
+		return "Function"
+	case reflect.Interface:
+		return "Interface"
+	case reflect.Struct:
+		if t.Name() != "" {
+			return t.Name()
+		}
+		return "Nested Struct"
+	case reflect.String:
+		name := t.Name()
+		if name != "" && name != "string" {
+			return name
+		}
+		return "String"
+	case reflect.Bool:
+		name := t.Name()
+		if name != "" && name != "bool" {
+			return name
+		}
+		return "Boolean"
+	case reflect.Int:
+		name := t.Name()
+		if name != "" && name != "int" {
+			return name
+		}
+		return "Integer"
+	case reflect.Int8:
+		name := t.Name()
+		if name != "" && name != "int8" {
+			return name
+		}
+		return "Integer(8 bits)"
+	case reflect.Int16:
+		name := t.Name()
+		if name != "" && name != "int16" {
+			return name
+		}
+		return "Integer(16 bits)"
+	case reflect.Int32:
+		name := t.Name()
+		if name != "" && name != "int32" {
+			return name
+		}
+		return "Integer(32 bits}"
+	case reflect.Int64:
+		name := t.Name()
+		if name != "" && name != "int64" {
+			return name
+		}
+		return "Integer(64 bits)"
+	case reflect.Uint:
+		name := t.Name()
+		if name != "" && name != "uint" {
+			return name
+		}
+		return "Unsigned Integer"
+	case reflect.Uint8:
+		name := t.Name()
+		if name != "" && name != "uint8" {
+			return name
+		}
+		return "Unsigned Integer(8 bits)"
+	case reflect.Uint16:
+		name := t.Name()
+		if name != "" && name != "uint16" {
+			return name
+		}
+		return "Unsigned Integer(16 bits)"
+	case reflect.Uint32:
+		name := t.Name()
+		if name != "" && name != "uint32" {
+			return name
+		}
+		return "Unsigned Integer(32 bits}"
+	case reflect.Uint64:
+		name := t.Name()
+		if name != "" && name != "uint64" {
+			return name
+		}
+		return "Unsigned Integer(64 bits)"
+	case reflect.Float32:
+		name := t.Name()
+		if name != "" && name != "float32" {
+			return name
+		}
+		return "Float"
+	case reflect.Float64:
+		name := t.Name()
+		if name != "" && name != "float64" {
+			return name
+		}
+		return "Float(64 bits)"
+	case reflect.Complex64:
+		return "Complex(64 bits)"
+	case reflect.Complex128:
+		return "Complex(128 bits)"
+	}
+	return fmt.Sprintf("%+v", t)
+}
+
+// Usage writes usage information to stderr using the default header and table format
+func Usage(prefix string, spec interface{}) error {
+	return Usagef(prefix, spec, os.Stderr, DefaultHeader, DefaultTableFormat)
+}
+
+// Usagef writes usage information to the specified io.Writer using the specifed header and usage format
+func Usagef(prefix string, spec interface{}, out io.Writer, header string, format string) error {
+
+	// gather first
+	infos, err := GatherInfo(prefix, spec)
+	if err != nil {
+		return err
+	}
+
+	if header != NoHeader {
+		headerTmpl, err := template.New("envconfig_header").Parse(header)
+		if err != nil {
+			return err
+		}
+		err = headerTmpl.Execute(out, path.Base(os.Args[0]))
+		if err != nil {
+			return err
+		}
+	}
+
+	var tabs *tabwriter.Writer = nil
+	var tmpl *template.Template
+	var tmplSpec = format
+	var usage usageInfo
+
+	// If format is prefixed with "table" then strip it off to get the per-line template, display the table headers,
+	// and inject a tab write filter
+	if strings.HasPrefix(format, "table") {
+		tmplSpec = strings.TrimPrefix(format, "table")
+		tmpl, err = template.New("envconfig").Parse(tmplSpec)
+		if err != nil {
+			return nil
+		}
+		tabs = tabwriter.NewWriter(out, 1, 0, 4, ' ', 0)
+		out = tabs
+
+		usage = usageInfo{
+			Key:         "KEY",
+			Description: "DESCRIPTION",
+			Type:        "TYPE",
+			Default:     "DEFAULT",
+			Required:    "REQUIRED",
+		}
+		if err = tmpl.Execute(out, usage); err != nil {
+			return err
+		}
+		fmt.Fprintln(out)
+	} else {
+		// Not a table, so just use given filter as is
+		tmpl, err = template.New("envconfig").Parse(tmplSpec)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, info := range infos {
+		req := info.Tags.Get("required")
+		if req != "" {
+			reqB, err := strconv.ParseBool(req)
+			if err != nil {
+				return err
+			}
+			if reqB {
+				req = "true"
+			}
+		}
+		usage = usageInfo{
+			Key:         info.Key,
+			Description: info.Tags.Get("desc"),
+			Type:        toTypeDescription(info.Field.Type()),
+			Default:     info.Tags.Get("default"),
+			Required:    req,
+		}
+
+		if err := tmpl.Execute(out, usage); err != nil {
+			return err
+		}
+		fmt.Fprintln(out)
+	}
+	// If we injected a tab writer then we need to flush
+	if tabs != nil {
+		tabs.Flush()
+	}
+
+	return nil
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2016 Kelsey Hightower and others. All rights reserved.
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file.
+
+package envconfig
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+var TestUsageDefaultResult string = `USAGE:.envconfig.test
+..This.application.is.configured.via.the.environment..The.following.environment
+..variables.can.used.specified:
+
+..KEY..............................................TYPE.........................DEFAULT...........REQUIRED....DESCRIPTION
+..ENV_CONFIG_EMBEDDED..............................Embedded...................................................can.we.document.a.struct
+..ENV_CONFIG_ENABLED...............................Boolean....................................................some.embedded.value
+..ENV_CONFIG_EMBEDDEDPORT..........................Integer....................................................
+..ENV_CONFIG_MULTIWORDVAR..........................String.....................................................
+..ENV_CONFIG_MULTI_WITH_DIFFERENT_ALT..............String.....................................................
+..ENV_CONFIG_EMBEDDED_WITH_ALT.....................String.....................................................
+..ENV_CONFIG_DEBUG.................................Boolean....................................................
+..ENV_CONFIG_PORT..................................Integer....................................................
+..ENV_CONFIG_RATE..................................Float......................................................
+..ENV_CONFIG_USER..................................String.....................................................
+..ENV_CONFIG_TTL...................................Unsigned.Integer(32.bits}..................................
+..ENV_CONFIG_TIMEOUT...............................Duration...................................................
+..ENV_CONFIG_ADMINUSERS............................List.of.String.............................................
+..ENV_CONFIG_MAGICNUMBERS..........................List.of.Integer............................................
+..ENV_CONFIG_MULTIWORDVAR..........................String.....................................................
+..ENV_CONFIG_SOMEPOINTER...........................Reference.to.String........................................
+..ENV_CONFIG_SOMEPOINTERWITHDEFAULT................Reference.to.String..........foo2baz.......................foorbar.is.the.word
+..ENV_CONFIG_MULTI_WORD_VAR_WITH_ALT...............String.....................................................what.alt
+..ENV_CONFIG_MULTI_WORD_VAR_WITH_LOWER_CASE_ALT....String.....................................................
+..ENV_CONFIG_SERVICE_HOST..........................String.....................................................
+..ENV_CONFIG_DEFAULTVAR............................String.......................foobar........................
+..ENV_CONFIG_REQUIREDVAR...........................String.........................................true........
+..ENV_CONFIG_BROKER................................String.......................127.0.0.1.....................
+..ENV_CONFIG_REQUIREDDEFAULT.......................String.......................foo2bar...........true........
+..ENV_CONFIG_OUTER.................................Nested.Struct..............................................
+..ENV_CONFIG_OUTER_INNER...........................String.....................................................
+..ENV_CONFIG_OUTER_PROPERTYWITHDEFAULT.............String.......................fuzzybydefault................
+..ENV_CONFIG_AFTERNESTED...........................String.....................................................
+..ENV_CONFIG_HONOR.................................HonorDecodeInStruct........................................
+..ENV_CONFIG_DATETIME..............................Time.......................................................
+`
+
+var TestUsageListResult string = `..ENV_CONFIG_EMBEDDED
+....[description].can.we.document.a.struct
+....[type]........Embedded
+....[default].....
+....[required]....
+..ENV_CONFIG_ENABLED
+....[description].some.embedded.value
+....[type]........Boolean
+....[default].....
+....[required]....
+..ENV_CONFIG_EMBEDDEDPORT
+....[description].
+....[type]........Integer
+....[default].....
+....[required]....
+..ENV_CONFIG_MULTIWORDVAR
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_MULTI_WITH_DIFFERENT_ALT
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_EMBEDDED_WITH_ALT
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_DEBUG
+....[description].
+....[type]........Boolean
+....[default].....
+....[required]....
+..ENV_CONFIG_PORT
+....[description].
+....[type]........Integer
+....[default].....
+....[required]....
+..ENV_CONFIG_RATE
+....[description].
+....[type]........Float
+....[default].....
+....[required]....
+..ENV_CONFIG_USER
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_TTL
+....[description].
+....[type]........Unsigned.Integer(32.bits}
+....[default].....
+....[required]....
+..ENV_CONFIG_TIMEOUT
+....[description].
+....[type]........Duration
+....[default].....
+....[required]....
+..ENV_CONFIG_ADMINUSERS
+....[description].
+....[type]........List.of.String
+....[default].....
+....[required]....
+..ENV_CONFIG_MAGICNUMBERS
+....[description].
+....[type]........List.of.Integer
+....[default].....
+....[required]....
+..ENV_CONFIG_MULTIWORDVAR
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_SOMEPOINTER
+....[description].
+....[type]........Reference.to.String
+....[default].....
+....[required]....
+..ENV_CONFIG_SOMEPOINTERWITHDEFAULT
+....[description].foorbar.is.the.word
+....[type]........Reference.to.String
+....[default].....foo2baz
+....[required]....
+..ENV_CONFIG_MULTI_WORD_VAR_WITH_ALT
+....[description].what.alt
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_MULTI_WORD_VAR_WITH_LOWER_CASE_ALT
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_SERVICE_HOST
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_DEFAULTVAR
+....[description].
+....[type]........String
+....[default].....foobar
+....[required]....
+..ENV_CONFIG_REQUIREDVAR
+....[description].
+....[type]........String
+....[default].....
+....[required]....true
+..ENV_CONFIG_BROKER
+....[description].
+....[type]........String
+....[default].....127.0.0.1
+....[required]....
+..ENV_CONFIG_REQUIREDDEFAULT
+....[description].
+....[type]........String
+....[default].....foo2bar
+....[required]....true
+..ENV_CONFIG_OUTER
+....[description].
+....[type]........Nested.Struct
+....[default].....
+....[required]....
+..ENV_CONFIG_OUTER_INNER
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_OUTER_PROPERTYWITHDEFAULT
+....[description].
+....[type]........String
+....[default].....fuzzybydefault
+....[required]....
+..ENV_CONFIG_AFTERNESTED
+....[description].
+....[type]........String
+....[default].....
+....[required]....
+..ENV_CONFIG_HONOR
+....[description].
+....[type]........HonorDecodeInStruct
+....[default].....
+....[required]....
+..ENV_CONFIG_DATETIME
+....[description].
+....[type]........Time
+....[default].....
+....[required]....
+`
+
+var TestUsageCustomResult = `ENV_CONFIG_EMBEDDED=can.we.document.a.struct
+ENV_CONFIG_ENABLED=some.embedded.value
+ENV_CONFIG_EMBEDDEDPORT=
+ENV_CONFIG_MULTIWORDVAR=
+ENV_CONFIG_MULTI_WITH_DIFFERENT_ALT=
+ENV_CONFIG_EMBEDDED_WITH_ALT=
+ENV_CONFIG_DEBUG=
+ENV_CONFIG_PORT=
+ENV_CONFIG_RATE=
+ENV_CONFIG_USER=
+ENV_CONFIG_TTL=
+ENV_CONFIG_TIMEOUT=
+ENV_CONFIG_ADMINUSERS=
+ENV_CONFIG_MAGICNUMBERS=
+ENV_CONFIG_MULTIWORDVAR=
+ENV_CONFIG_SOMEPOINTER=
+ENV_CONFIG_SOMEPOINTERWITHDEFAULT=foorbar.is.the.word
+ENV_CONFIG_MULTI_WORD_VAR_WITH_ALT=what.alt
+ENV_CONFIG_MULTI_WORD_VAR_WITH_LOWER_CASE_ALT=
+ENV_CONFIG_SERVICE_HOST=
+ENV_CONFIG_DEFAULTVAR=
+ENV_CONFIG_REQUIREDVAR=
+ENV_CONFIG_BROKER=
+ENV_CONFIG_REQUIREDDEFAULT=
+ENV_CONFIG_OUTER=
+ENV_CONFIG_OUTER_INNER=
+ENV_CONFIG_OUTER_PROPERTYWITHDEFAULT=
+ENV_CONFIG_AFTERNESTED=
+ENV_CONFIG_HONOR=
+ENV_CONFIG_DATETIME=
+`
+
+var TestUsageBadFormatResult = `{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+{.Key}
+`
+
+func compareUsage(want, got string, t *testing.T) {
+	have := strings.Replace(got, " ", ".", -1)
+	if want != have {
+		shortest := len(want)
+		if len(have) < shortest {
+			shortest = len(have)
+		}
+		if len(want) != len(have) {
+			t.Errorf("expected result length of %d, found %d", len(want), len(have))
+		}
+		for i := 0; i < shortest; i++ {
+			if want[i] != have[i] {
+				t.Errorf("difference at index %d, expected '%c' (%v), found '%c' (%v)\n",
+					i, want[i], want[i], have[i], have[i])
+				break
+			}
+		}
+		t.Errorf("Complete Expected:\n'%s'\nComplete Found:\n'%s'\n", want, have)
+	}
+}
+
+func TestUsageDefault(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, DefaultHeader, DefaultTableFormat)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	compareUsage(TestUsageDefaultResult, buf.String(), t)
+}
+
+func TestUsageWithoutHeader(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, NoHeader, DefaultTableFormat)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	compareUsage(TestUsageDefaultResult[135:], buf.String(), t)
+}
+
+func TestUsageList(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, NoHeader, DefaultListFormat)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	compareUsage(TestUsageListResult, buf.String(), t)
+}
+
+func TestUsageCustomFormat(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, NoHeader, "{{.Key}}={{.Description}}")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	compareUsage(TestUsageCustomResult, buf.String(), t)
+}
+
+func TestUsageUnknownKeyFormat(t *testing.T) {
+	var s Specification
+	unknownError := "template: envconfig:1:2: executing \"envconfig\" at <.UnknownKey>"
+	os.Clearenv()
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, NoHeader, "{{.UnknownKey}}")
+	if err == nil {
+		t.Errorf("expected 'unknown key' error, but got no error")
+	}
+	if strings.Index(err.Error(), unknownError) == -1 {
+		t.Errorf("expected '%s', but got '%s'", unknownError, err.Error())
+	}
+}
+
+func TestUsageBadFormat(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	// If you don't use two {{}} then you get a lieteral
+	buf := new(bytes.Buffer)
+	err := Usagef("env_config", &s, buf, NoHeader, "{.Key}")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	compareUsage(TestUsageBadFormatResult, buf.String(), t)
+}


### PR DESCRIPTION
there is now a `GatherInformation` phase and then two second phases, `Process` to populate the structure, and `Usage` to output usage information.

The `GatherInformation` and associated structure `VarInfo` are public / exposed so that additional behavior can be written outside of the core package if desired.