### PR TITLE
Store the low level error that raised ParseError

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -25,6 +25,7 @@ type ParseError struct {
 	FieldName string
 	TypeName  string
 	Value     string
+	Err       error
 }
 
 // Decoder has the same semantics as Setter, but takes higher precedence.
@@ -40,7 +41,7 @@ type Setter interface {
 }
 
 func (e *ParseError) Error() string {
-	return fmt.Sprintf("envconfig.Process: assigning %[1]s to %[2]s: converting '%[3]s' to type %[4]s", e.KeyName, e.FieldName, e.Value, e.TypeName)
+	return fmt.Sprintf("envconfig.Process: assigning %[1]s to %[2]s: converting '%[3]s' to type %[4]s. details: %[5]s", e.KeyName, e.FieldName, e.Value, e.TypeName, e.Err)
 }
 
 // Process populates the specified struct based on environment variables
@@ -133,6 +134,7 @@ func Process(prefix string, spec interface{}) error {
 				FieldName: fieldName,
 				TypeName:  f.Type().String(),
 				Value:     value,
+				Err:       err,
 			}
 		}
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -602,6 +602,17 @@ func TestTextUnmarshalerError(t *testing.T) {
 	if v.FieldName != "Datetime" {
 		t.Errorf("expected %s, got %v", "Debug", v.FieldName)
 	}
+
+	expectedLowLevelError := time.ParseError{
+		Layout:     time.RFC3339,
+		Value:      "I'M NOT A DATE",
+		LayoutElem: "2006",
+		ValueElem:  "I'M NOT A DATE",
+	}
+
+	if v.Err.Error() != expectedLowLevelError.Error() {
+		t.Errorf("expected %s, got %s", expectedLowLevelError, v.Err)
+	}
 	if s.Debug != false {
 		t.Errorf("expected %v, got %v", false, s.Debug)
 	}


### PR DESCRIPTION
In some sittuations we would like to know exactly what caused the ParseError in
a specific field. With this change the error message from ParseError would
be different (with an extra details section):

    envconfig.Process: assigning TEST_VAR1 to var1: converting 'hello' to type int. details: strconv.ParseInt: parsing "hello": invalid syntax