### PR TITLE
Adding build tags to use `os.LookupEnv` in >=go1.5

### DIFF
--- a/env_os.go
+++ b/env_os.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build appengine
 
 package envconfig
 

--- a/env_os.go
+++ b/env_os.go
@@ -1,4 +1,4 @@
-// +build !go1.5
+// +build go1.5
 
 package envconfig
 

--- a/env_os.go
+++ b/env_os.go
@@ -1,0 +1,7 @@
+// +build !go1.5
+
+package envconfig
+
+import "os"
+
+var lookupEnv = os.LookupEnv

--- a/env_syscall.go
+++ b/env_syscall.go
@@ -1,4 +1,4 @@
-// +build go1.5
+// +build !go1.5
 
 package envconfig
 

--- a/env_syscall.go
+++ b/env_syscall.go
@@ -1,4 +1,4 @@
-// +build !go1.5
+// +build !appengine
 
 package envconfig
 

--- a/env_syscall.go
+++ b/env_syscall.go
@@ -1,0 +1,7 @@
+// +build go1.5
+
+package envconfig
+
+import "syscall"
+
+var lookupEnv = syscall.Getenv

--- a/envconfig.go
+++ b/envconfig.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -107,11 +106,12 @@ func Process(prefix string, spec interface{}) error {
 
 		// `os.Getenv` cannot differentiate between an explicitly set empty value
 		// and an unset value. `os.LookupEnv` is preferred to `syscall.Getenv`,
-		// but it is only available in go1.5 or newer.
-		value, ok := syscall.Getenv(key)
+		// but it is only available in go1.5 or newer. We're using Go build tags
+		// here to use os.LookupEnv for >=go1.5
+		value, ok := lookupEnv(key)
 		if !ok && alt != "" {
 			key := strings.ToUpper(fieldName)
-			value, ok = syscall.Getenv(key)
+			value, ok = lookupEnv(key)
 		}
 
 		def := ftype.Tag.Get("default")


### PR DESCRIPTION
This PR adds build tags and a small level of indirection to swap out `syscall.Getenv` for `os.LookupEnv` in environments with >=go1.5.

I'm currently doing work with App Engine and would love to use `github.com/NYTimes/gizmo/pubsub`, but this is the one dependency left in there that makes a reference to the `syscall` package which is not available in the AE standard environment. This PR will enable the use of `envconfig` in App Engine.