### PR TITLE
Add support for auto underscoring CamelCased fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,28 @@ For example, consider the following struct:
 
 ```Go
 type Specification struct {
-    MultiWordVar string `envconfig:"multi_word_var"`
-    DefaultVar   string `default:"foobar"`
-    RequiredVar  string `required:"true"`
-    IgnoredVar   string `ignored:"true"`
+    ManualOverride1 string `envconfig:"manual_override_1"`
+    DefaultVar      string `default:"foobar"`
+    RequiredVar     string `required:"true"`
+    IgnoredVar      string `ignored:"true"`
+    AutoSplitVar    string `multi_word:"true"`
 }
 ```
 
-Envconfig will process value for `MultiWordVar` by populating it with the
-value for `MYAPP_MULTI_WORD_VAR`.
+Envconfig has automatic support for camelcased struct elements when the
+`multi_word:"true"` tag is supplied. Without this tag, `AutoSplitVar` above
+would look for an environment variable called `MYAPP_AUTOSPLITVAR`. With the
+setting applied it will look for `MYAPP_AUTO_SPLIT_VAR`. Note that numbers
+will get globbed into the previous word. If the setting does not do the
+right thing, you may use a manual override.
+
+Envconfig will process value for `ManualOverride` by populating it with the
+value for `MYAPP_MANUAL_OVERRIDE_1`.
 
 ```Bash
-export MYAPP_MULTI_WORD_VAR="this will be the value"
+export MYAPP_MANUAL_OVERRIDE_1="this will be the value"
 
-# export MYAPP_MULTIWORDVAR="and this will not"
+# export MYAPP_MANUALOVERRIDE1="and this will not"
 ```
 
 If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,

--- a/envconfig.go
+++ b/envconfig.go
@@ -79,30 +79,30 @@ func Process(prefix string, spec interface{}) error {
 		}
 
 		// Default to the field name as the env var name (will be upcased)
-		fieldName := ftype.Name
+		key := ftype.Name
 
 		// Best effort to un-pick camel casing as separate words
-		if ftype.Tag.Get("multi_word") == "true" {
+		if ftype.Tag.Get("split_words") == "true" {
 			words := expr.FindAllStringSubmatch(ftype.Name, -1)
 			if len(words) > 0 {
 				var name []string
 				for _, words := range words {
-					name = append(name, strings.ToUpper(words[0]))
+					name = append(name, words[0])
 				}
 
-				fieldName = strings.Join(name, "_")
+				key = strings.Join(name, "_")
 			}
 		}
 
 		alt := ftype.Tag.Get("envconfig")
 		if alt != "" {
-			fieldName = alt
+			key = alt
 		}
 
-		key := fieldName
 		if prefix != "" {
 			key = fmt.Sprintf("%s_%s", prefix, key)
 		}
+
 		key = strings.ToUpper(key)
 
 		if f.Kind() == reflect.Struct {
@@ -129,7 +129,7 @@ func Process(prefix string, spec interface{}) error {
 		// here to use os.LookupEnv for >=go1.5
 		value, ok := lookupEnv(key)
 		if !ok && alt != "" {
-			key := strings.ToUpper(fieldName)
+			key := strings.ToUpper(alt)
 			value, ok = lookupEnv(key)
 		}
 
@@ -150,7 +150,7 @@ func Process(prefix string, spec interface{}) error {
 		if err != nil {
 			return &ParseError{
 				KeyName:   key,
-				FieldName: fieldName,
+				FieldName: ftype.Name,
 				TypeName:  f.Type().String(),
 				Value:     value,
 				Err:       err,

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -33,6 +33,7 @@ type Specification struct {
 	AdminUsers                   []string
 	MagicNumbers                 []int
 	MultiWordVar                 string
+	MultiWordVarWithAutoSplit    string  `multi_word:"true"`
 	SomePointer                  *string
 	SomePointerWithDefault       *string `default:"foo2baz"`
 	MultiWordVarWithAlt          string  `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
@@ -84,6 +85,7 @@ func TestProcess(t *testing.T) {
 	os.Setenv("ENV_CONFIG_AFTERNESTED", "after")
 	os.Setenv("ENV_CONFIG_HONOR", "honor")
 	os.Setenv("ENV_CONFIG_DATETIME", "2016-08-16T18:57:05Z")
+	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "shakespeare")
 	err := Process("env_config", &s)
 	if err != nil {
 		t.Error(err.Error())
@@ -146,6 +148,10 @@ func TestProcess(t *testing.T) {
 
 	if expected := time.Date(2016, 8, 16, 18, 57, 05, 0, time.UTC); !s.Datetime.Equal(expected) {
 		t.Errorf("expected %s, got %s", expected.Format(time.RFC3339), s.Datetime.Format(time.RFC3339))
+	}
+
+	if s.MultiWordVarWithAutoSplit != "shakespeare" {
+		t.Errorf("expected %q, got %q", "shakespeare", s.MultiWordVarWithAutoSplit)
 	}
 }
 

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -33,7 +33,7 @@ type Specification struct {
 	AdminUsers                   []string
 	MagicNumbers                 []int
 	MultiWordVar                 string
-	MultiWordVarWithAutoSplit    string  `multi_word:"true"`
+	MultiWordVarWithAutoSplit    uint32  `split_words:"true"`
 	SomePointer                  *string
 	SomePointerWithDefault       *string `default:"foo2baz"`
 	MultiWordVarWithAlt          string  `envconfig:"MULTI_WORD_VAR_WITH_ALT"`
@@ -85,7 +85,7 @@ func TestProcess(t *testing.T) {
 	os.Setenv("ENV_CONFIG_AFTERNESTED", "after")
 	os.Setenv("ENV_CONFIG_HONOR", "honor")
 	os.Setenv("ENV_CONFIG_DATETIME", "2016-08-16T18:57:05Z")
-	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "shakespeare")
+	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "24")
 	err := Process("env_config", &s)
 	if err != nil {
 		t.Error(err.Error())
@@ -150,8 +150,8 @@ func TestProcess(t *testing.T) {
 		t.Errorf("expected %s, got %s", expected.Format(time.RFC3339), s.Datetime.Format(time.RFC3339))
 	}
 
-	if s.MultiWordVarWithAutoSplit != "shakespeare" {
-		t.Errorf("expected %q, got %q", "shakespeare", s.MultiWordVarWithAutoSplit)
+	if s.MultiWordVarWithAutoSplit != 24 {
+		t.Errorf("expected %q, got %q", 24, s.MultiWordVarWithAutoSplit)
 	}
 }
 
@@ -223,6 +223,23 @@ func TestParseErrorUint(t *testing.T) {
 	}
 	if s.TTL != 0 {
 		t.Errorf("expected %v, got %v", 0, s.TTL)
+	}
+}
+
+func TestParseErrorSplitWords(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "shakespeare")
+	err := Process("env_config", &s)
+	v, ok := err.(*ParseError)
+	if !ok {
+		t.Errorf("expected ParseError, got %v", v)
+	}
+	if v.FieldName != "MultiWordVarWithAutoSplit" {
+		t.Errorf("expected %s, got %v", "", v.FieldName)
+	}
+	if s.MultiWordVarWithAutoSplit != 0 {
+		t.Errorf("expected %v, got %v", 0, s.MultiWordVarWithAutoSplit)
 	}
 }
 


### PR DESCRIPTION
This adds support for automatically turning `MultiWordField` into `MULTI_WORD_FIELD` by adding the struct tag `multi_word:"true"`. This is thus backward compatible but adds nice automatic support for most struct fields.

This closes #60 

Note that further information is in the README in this PR.
