### PR TITLE
adding a method to process variables from etcd with the attending tes…

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -5,6 +5,7 @@
 package envconfig
 
 import (
+	"context"
 	"encoding"
 	"errors"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/coreos/etcd/client"
 )
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
@@ -183,6 +186,27 @@ func Process(prefix string, spec interface{}) error {
 	}
 
 	return err
+}
+
+// ProcessFromEtcd modifies lookupFunc so that values come from the etcd
+// KeysAPI passed in as an argument, then calls Process as per usual
+func ProcessFromEtcd(prefix string, spec interface{}, kapi client.KeysAPI) error {
+	type lookupEnvFunc func(key string) (value string, found bool)
+	defer func(oldLookup lookupEnvFunc) {
+		lookupEnv = oldLookup
+	}(lookupEnv)
+	lookupEnv = func(key string) (value string, found bool) {
+		key = "/" + key
+		result, err := kapi.Get(context.Background(), key, nil)
+		if err != nil {
+			return "", false
+		}
+		if result == nil || result.Node == nil {
+			return "", false
+		}
+		return result.Node.Value, true
+	}
+	return Process(prefix, spec)
 }
 
 // MustProcess is the same as Process but panics if an error occurs

--- a/envconfig.go
+++ b/envconfig.go
@@ -5,7 +5,6 @@
 package envconfig
 
 import (
-	"context"
 	"encoding"
 	"errors"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 )
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.


### PR DESCRIPTION
I thought it might be helpful to add the capacity to process "environment" variables from etcd, so I've added a function here to do that with a corresponding test case.

I have not added a vendor directory because I didn't see one here already, but I'm willing to do it if you think it's appropriate.