### PR TITLE
force use of `os.LookupEnv` when go1.5 (due to cacheing in go1.10)

### DIFF
--- a/env_os.go
+++ b/env_os.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine go1.5
 
 package envconfig
 

--- a/env_syscall.go
+++ b/env_syscall.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!go1.5
 
 package envconfig
 


### PR DESCRIPTION
go1.10 caches env var accesses, but only when using `os.LookupEnv`
(`syscall.Getenv` does not record env var accesses so cache seems
reusable even if env vars have changed)

fixes #107