### PR TITLE
readme: Document required but empty behavior for #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,
 it will populate it with "foobar" as a default value.
 
 If envconfig can't find an environment variable value for `MYAPP_REQUIREDVAR`,
-it will return an error when asked to process the struct.
+it will return an error when asked to process the struct.  If
+`MYAPP_REQUIREDVAR` is present but empty, envconfig will not return an error.
 
 If envconfig can't find an environment variable in the form `PREFIX_MYVAR`, and there
 is a struct tag defined, it will try to populate your variable with an environment


### PR DESCRIPTION
Document the behavior of required:"true" when dealing with environment variables set to ""