### PR TITLE
Fixed comments for Usage() function

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -106,7 +106,7 @@ func toTypeDescription(t reflect.Type) string {
 	return fmt.Sprintf("%+v", t)
 }
 
-// Usage writes usage information to stderr using the default header and table format
+// Usage writes usage information to stdout using the default header and table format
 func Usage(prefix string, spec interface{}) error {
 	// The default is to output the usage information as a table
 	// Create tabwriter instance to support table output


### PR DESCRIPTION
Fixed comments for Usage() function.
It actually writes to stdout instead of stderr.

```
tabs := tabwriter.NewWriter(os.Stdout, 1, 0, 4, ' ', 0)
```