### PR TITLE
Added an example of having more than one Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ type Specification struct {
     RequiredVar     string `required:"true"`
     IgnoredVar      string `ignored:"true"`
     AutoSplitVar    string `split_words:"true"`
+    RequiredAndAutoSplitVar    string `required:"true" split_words:"true"`
 }
 ```
 


### PR DESCRIPTION
Provides an example of having more than one Tag, to prevent confusions like this https://github.com/kelseyhightower/envconfig/issues/120