### PR TITLE
Added function to detect unused configs

### DIFF
--- a/unused.go
+++ b/unused.go
@@ -1,0 +1,61 @@
+package envconfig
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+var envVarNameRegex = regexp.MustCompile("^[^=]*")
+
+// Unused returns the list of env vars that are defined right now
+// but are not being parsed by envconfig for the prefix given
+// If prefix is empty, it will check all the env vars available
+// and return the ones that are not being parsed.
+func Unused(prefix string, spec interface{}) ([]string, error) {
+	re, err := applicableRegex(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// build a map with used env vars as keys
+	infos, err := gatherInfo(prefix, spec)
+	used := make(map[string]struct{}, len(infos))
+	for _, v := range infos {
+		used[v.Key] = struct{}{}
+		if v.Alt != "" {
+			used[v.Alt] = struct{}{}
+		}
+	}
+
+	var unused []string
+
+	// read all the defined env vars, if begins with same prefix and is not in the previous map, it's unused
+	for _, envName := range envVarsNames() {
+		if !re.MatchString(envName) {
+			continue
+		}
+		if _, used := used[envName]; envName != "" && !used {
+			unused = append(unused, envName)
+		}
+	}
+
+	return unused, nil
+}
+
+func envVarsNames() []string {
+	environ := os.Environ()
+	names := make([]string, len(environ))
+	for i, env := range environ {
+		names[i] = envVarNameRegex.FindString(env)
+	}
+	return names
+}
+
+func applicableRegex(prefix string) (*regexp.Regexp, error) {
+	if prefix == "" {
+		return regexp.Compile(".+")
+	}
+	upperPrefix := strings.ToUpper(prefix)
+	return regexp.Compile("^" + upperPrefix + "_")
+}

--- a/unused_test.go
+++ b/unused_test.go
@@ -1,0 +1,81 @@
+package envconfig
+
+import (
+	"os"
+	"sort"
+	"testing"
+)
+
+func TestUnused(t *testing.T) {
+	spec := struct {
+		Used   string
+		Unset  string
+		Nested struct {
+			Used  string
+			Unset string
+		}
+	}{}
+
+	t.Run("with prefix", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("TEST_UNUSED_CONFIGS_USED", "set")
+		os.Setenv("TEST_UNUSED_CONFIGS_UNUSED", "set")
+		os.Setenv("UNRELATED_UNUSED", "set")
+		os.Setenv("TEST_UNUSED_CONFIGS_NESTED_USED", "set")
+		os.Setenv("TEST_UNUSED_CONFIGS_NESTED_UNUSED", "set")
+
+		unused, err := Unused("test_unused_configs", &spec)
+		if err != nil {
+			t.Fatalf("Err shuold be nil, was: %s", err)
+		}
+
+		expectedUnused := []string{
+			"TEST_UNUSED_CONFIGS_UNUSED",
+			"TEST_UNUSED_CONFIGS_NESTED_UNUSED",
+		}
+		sort.Strings(unused)
+		sort.Strings(expectedUnused)
+
+		if !equal(expectedUnused, unused) {
+			t.Errorf("Expected %+v as unused vars, got %+v", expectedUnused, unused)
+		}
+	})
+
+	t.Run("without prefix", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("USED", "set")
+		os.Setenv("UNUSED", "set")
+		os.Setenv("UNRELATED", "set")
+		os.Setenv("NESTED_USED", "set")
+		os.Setenv("NESTED_UNUSED", "set")
+
+		unused, err := Unused("", &spec)
+		if err != nil {
+			t.Fatalf("Err shuold be nil, was: %s", err)
+		}
+
+		expectedUnused := []string{
+			"UNUSED",
+			"NESTED_UNUSED",
+			"UNRELATED",
+		}
+		sort.Strings(unused)
+		sort.Strings(expectedUnused)
+
+		if !equal(expectedUnused, unused) {
+			t.Errorf("Expected %+v as unused vars, got %+v", expectedUnused, unused)
+		}
+	})
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
As service keeps growing, it starts to have tens of configurations, and some of them become deprecated by the code but still persist in the configuration.

In order to detect those vars, we can use the information of the config provided and the config that is being parsed by current code version.