### PR TITLE
Add time.Duration to list of supported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ envconfig supports these struct field types:
   * maps (keys and values of any supported type)
   * [encoding.TextUnmarshaler](https://golang.org/pkg/encoding/#TextUnmarshaler)
   * [encoding.BinaryUnmarshaler](https://golang.org/pkg/encoding/#BinaryUnmarshaler)
+  * [time.Duration](https://golang.org/pkg/time/#Duration)
 
 Embedded structs using these fields are also supported.
 


### PR DESCRIPTION
This type is shown in the example with the annotations, but isn't listed explicitly in the supported types.