### PR TITLE
Group missing required field errors.

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -184,6 +184,7 @@ func CheckDisallowed(prefix string, spec interface{}) error {
 func Process(prefix string, spec interface{}) error {
 	infos, err := gatherInfo(prefix, spec)
 
+	var missingKeys []string
 	for _, info := range infos {
 
 		// `os.Getenv` cannot differentiate between an explicitly set empty value
@@ -207,7 +208,7 @@ func Process(prefix string, spec interface{}) error {
 				if info.Alt != "" {
 					key = info.Alt
 				}
-				return fmt.Errorf("required key %s missing value", key)
+				missingKeys = append(missingKeys, key)
 			}
 			continue
 		}
@@ -222,6 +223,10 @@ func Process(prefix string, spec interface{}) error {
 				Err:       err,
 			}
 		}
+	}
+
+	if len(missingKeys) > 0 {
+		return fmt.Errorf("required key(s) missing values: %s", strings.Join(missingKeys, ","))
 	}
 
 	return err

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -794,7 +794,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()
@@ -804,8 +804,26 @@ func TestErrorMessageForRequiredAltVar(t *testing.T) {
 		t.Error("no failure when missing required variable")
 	}
 
-	if !strings.Contains(err.Error(), " BAR ") {
+	if !strings.Contains(err.Error(), " BAR") {
 		t.Errorf("expected error message to contain BAR, got \"%v\"", err)
+	}
+}
+
+func TestErrorMessageForMultipleRequiredAltVar(t *testing.T) {
+	var s struct {
+		Foo string `envconfig:"FOO" required:"true"`
+		Bar string `envconfig:"BAR" required:"true"`
+	}
+
+	os.Clearenv()
+	err := Process("env_config", &s)
+
+	if err == nil {
+		t.Error("no failure when missing required variables")
+	}
+
+	if !strings.Contains(err.Error(), " FOO,BAR") {
+		t.Errorf("expected error message to contain FOO, BAR, got \"%v\"", err)
 	}
 }
 


### PR DESCRIPTION
Don't stop processing when an required variable is missing, instead build a list of the missing variables, and throw a single error at the end.

This change results in an error message such as
`required key(s) missing values: FOO,BAR`

Related to https://github.com/kelseyhightower/envconfig/issues/143