### PR TITLE
Enhance huge performance: reduce calculation time and memory allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# go
+cpu.out
+mem.out
+cpu.svg
+mem.svg
+*.test

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,13 @@
+# v1.4.0
+
+```
+go test -v  -bench=. -run=none \
+        -benchtime=300000x -benchmem \
+        -memprofile mem.out -cpuprofile cpu.out .
+goos: linux
+goarch: amd64
+pkg: github.com/kelseyhightower/envconfig
+BenchmarkGatherInfo-4             300000             41525 ns/op           17344 B/op        270 allocs/op
+PASS
+ok      github.com/kelseyhightower/envconfig    12.652s
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+test:
+	go test -v -race
+
+# This is only used by go 1.12
+bench:
+	go test -v -bench=. -run=none \
+		-benchtime=300000x -benchmem \
+		-memprofile mem.out -cpuprofile cpu.out .
+
+install_graphviz:
+	sudo apt install graphviz
+
+cpu_pprof:
+	go tool pprof -svg cpu.out > cpu.svg
+
+mem_pprof:
+	go tool pprof -svg mem.out > mem.svg

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -794,7 +794,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()
@@ -857,6 +857,8 @@ func BenchmarkGatherInfo(b *testing.B) {
 	os.Setenv("ENV_CONFIG_HONOR", "honor")
 	os.Setenv("ENV_CONFIG_DATETIME", "2016-08-16T18:57:05Z")
 	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "24")
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var s Specification
 		gatherInfo("env_config", &s)

--- a/func.go
+++ b/func.go
@@ -1,0 +1,44 @@
+package envconfig
+
+import (
+	"encoding"
+	"reflect"
+	"strconv"
+)
+
+func interfaceFrom(field reflect.Value, fn func(interface{}, *bool)) {
+	// it may be impossible for a struct field to fail this check
+	if !field.CanInterface() {
+		return
+	}
+	var ok bool
+	fn(field.Interface(), &ok)
+	if !ok && field.CanAddr() {
+		fn(field.Addr().Interface(), &ok)
+	}
+}
+
+func decoderFrom(field reflect.Value) (d Decoder) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { d, *ok = v.(Decoder) })
+	return d
+}
+
+func setterFrom(field reflect.Value) (s Setter) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { s, *ok = v.(Setter) })
+	return s
+}
+
+func textUnmarshaler(field reflect.Value) (t encoding.TextUnmarshaler) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { t, *ok = v.(encoding.TextUnmarshaler) })
+	return t
+}
+
+func binaryUnmarshaler(field reflect.Value) (b encoding.BinaryUnmarshaler) {
+	interfaceFrom(field, func(v interface{}, ok *bool) { b, *ok = v.(encoding.BinaryUnmarshaler) })
+	return b
+}
+
+func isTrue(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/kelseyhightower/envconfig
+
+go 1.12

--- a/type.go
+++ b/type.go
@@ -1,0 +1,13 @@
+package envconfig
+
+// Decoder has the same semantics as Setter, but takes higher precedence.
+// It is provided for historical compatibility.
+type Decoder interface {
+	Decode(value string) error
+}
+
+// Setter is implemented by types can self-deserialize values.
+// Any type that implements flag.Value also implements Setter.
+type Setter interface {
+	Set(value string) error
+}


### PR DESCRIPTION
Before:
```
go test -v -bench=. -run=none \
         -benchtime=300000x -benchmem \
         -memprofile mem.out -cpuprofile cpu.out .
goos: linux
goarch: amd64
pkg: github.com/kelseyhightower/envconfig
BenchmarkGatherInfo-4             300000             39701 ns/op           17317 B/op        270 allocs/op
PASS
ok      github.com/kelseyhightower/envconfig    12.056s
```

After:
```
go test -v -bench=. -run=none \
        -benchtime=300000x -benchmem \
        -memprofile mem.out -cpuprofile cpu.out .
goos: linux
goarch: amd64
pkg: github.com/kelseyhightower/envconfig
BenchmarkGatherInfo-4             300000             31735 ns/op           16079 B/op        194 allocs/op
PASS
ok      github.com/kelseyhightower/envconfig    9.739s
```

Please note:

`ns/op`: 39701 -> 31735 **(-20%)**
`B/op`: 17317 -> 16079 **(-7.2%)**
`allocs/op`: 270 -> 194 **(-28.2%)**

----

Attachment with cpu and mem profile about difference:

(Github can't accept SVG of upload, so I compress as **GZ**)

[profile.tar.gz](https://github.com/kelseyhightower/envconfig/files/3513281/profile.tar.gz)
