### PR TITLE
Trim String which is surrounded by white space

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -265,7 +265,7 @@ func processField(value string, field reflect.Value) error {
 
 	switch typ.Kind() {
 	case reflect.String:
-		field.SetString(value)
+		field.SetString(strings.TrimSpace(value))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		var (
 			val int64


### PR DESCRIPTION
I'd like to remove white space when we use string type field.

```
$ cat main.go
package main

import (
	"fmt"
	"github.com/kelseyhightower/envconfig"
)

type A struct {
	B string `envconfig:"B"`
}

func main() {
	var a A
	if err := envconfig.Process("", &a); err != nil {
		fmt.Println(err)
		return
	}

	fmt.Println(a.B)
}

$  B="   a" go run main.go
   a
```