### PR TITLE
Don't set default value if struct field is already populated

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ export MYAPP_MANUAL_OVERRIDE_1="this will be the value"
 # export MYAPP_MANUALOVERRIDE1="and this will not"
 ```
 
+If no environment variable matches a struct field and this struct field is already populated (non zero value), envconfig will not set the default value.
+
 If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,
 it will populate it with "foobar" as a default value.
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -195,6 +195,10 @@ func Process(prefix string, spec interface{}) error {
 			value, ok = lookupEnv(info.Alt)
 		}
 
+		if !info.Field.IsZero() && !ok {
+			continue
+		}
+
 		def := info.Tags.Get("default")
 		if def != "" && !ok {
 			value = def

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -448,6 +448,17 @@ func TestAlternateNameDefaultVar(t *testing.T) {
 		t.Error(err.Error())
 	}
 
+	if s.NoPrefixDefault != "betterbroker" {
+		t.Errorf("expected %q, got %q", "betterbroker", s.NoPrefixDefault)
+	}
+
+	os.Clearenv()
+	s.NoPrefixDefault = ""
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "foo")
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+
 	if s.NoPrefixDefault != "127.0.0.1" {
 		t.Errorf("expected %q, got %q", "127.0.0.1", s.NoPrefixDefault)
 	}
@@ -794,7 +805,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/kelseyhightower/envconfig
+module github.com/davidterranova/envconfig
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
-module github.com/davidterranova/envconfig
-
-go 1.13
+module github.com/kelseyhightower/envconfig


### PR DESCRIPTION
The goal of this PR is to apply defaults only if the two following conditions are matched :
- No environment variable matches the struct field
- The struct field value is the zero value

This change allow envconfig to be integrated with a more general config system that loads the config from a different provider and override values from environment variables if they are defined / with a zero value