### PR TITLE
AdingPowerSupportFor_golang-github-kelseyhightower-envconfig-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch: 
+  - ppc64le
+  - amd64
 language: go
 
 go:
@@ -11,3 +14,7 @@ go:
   - 1.11.x
   - 1.12.x
   - tip
+jobs:
+ exclude:
+  - go: 1.4.x
+    arch: ppc64le


### PR DESCRIPTION
Adding Power Support
Excluding jobs for go version 1.4.x as the same is not supported for power.
The build is successful for rest all. Please find the Travis Link: https://travis-ci.com/github/santosh653/envconfig

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
