### PR TITLE
Support colon in map values

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -321,7 +321,7 @@ func processField(value string, field reflect.Value) error {
 		if len(strings.TrimSpace(value)) != 0 {
 			pairs := strings.Split(value, ",")
 			for _, pair := range pairs {
-				kvpair := strings.Split(pair, ":")
+				kvpair := strings.SplitN(pair, ":", 2)
 				if len(kvpair) != 2 {
 					return fmt.Errorf("invalid map item: %q", pair)
 				}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -497,6 +497,32 @@ func TestEmptyMapFieldOverride(t *testing.T) {
 	}
 }
 
+func TestEmptyMapFieldColonOverlap(t *testing.T) {
+	var s Specification
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "foo")
+	os.Setenv("ENV_CONFIG_MAPFIELD", "one:localhost:1234,two:localhost:2345")
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err)
+	}
+
+	if s.MapField == nil {
+		t.Error("expected empty map, got <nil>")
+	}
+
+	if len(s.MapField) != 2 {
+		t.Errorf("expected map size 2, got map of size %d", len(s.MapField))
+	}
+
+	if one := s.MapField["one"]; one != "localhost:1234" {
+		t.Errorf("expected map[one] = localhost:1234, got %s", one)
+	}
+
+	if one := s.MapField["two"]; one != "localhost:2345" {
+		t.Errorf("expected map[two] = localhost:2345, got %s", one)
+	}
+}
+
 func TestMustProcess(t *testing.T) {
 	var s Specification
 	os.Clearenv()
@@ -794,7 +820,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()

--- a/usage_test.go
+++ b/usage_test.go
@@ -75,7 +75,6 @@ func TestUsageDefault(t *testing.T) {
 	save := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
-	err := Usage("env_config", &s)
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
@@ -83,6 +82,7 @@ func TestUsageDefault(t *testing.T) {
 		io.Copy(&buf, r)
 		outC <- buf.String()
 	}()
+	err := Usage("env_config", &s)
 	w.Close()
 	os.Stdout = save // restoring the real stdout
 	out := <-outC


### PR DESCRIPTION
Since colon character ':' is being used as key-value delimiter that might cause problems when you want to have a map of name=url
By using SplitN we can grab the first : which should be the end of the key name and allow having one or more colons within the value without any issues.