### PR TITLE
deprecate Decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ envconfig supports these struct field types:
 
 Embedded structs using these fields are also supported.
 
-## Custom Decoders
+## Custom Setters
 
-Any field whose type (or pointer-to-type) implements `envconfig.Decoder` can
+Any field whose type (or pointer-to-type) implements `envconfig.Setter` can
 control its own deserialization:
 
 ```Bash
@@ -176,15 +176,15 @@ export DNS_SERVER=8.8.8.8
 ```
 
 ```Go
-type IPDecoder net.IP
+type IPSetter net.IP
 
-func (ipd *IPDecoder) Decode(value string) error {
-    *ipd = IPDecoder(net.ParseIP(value))
+func (ipd *IPSetter) Set(value string) error {
+    *ipd = IPSetter(net.ParseIP(value))
     return nil
 }
 
 type DNSConfig struct {
-    Address IPDecoder `envconfig:"DNS_SERVER"`
+    Address IPSetter `envconfig:"DNS_SERVER"`
 }
 ```
 
@@ -200,9 +200,9 @@ type providerDetails struct {
 	Weight int
 }
 
-type SMSProviderDecoder map[string][]providerDetails
+type SMSProviderSetter map[string][]providerDetails
 
-func (sd *SMSProviderDecoder) Decode(value string) error {
+func (sd *SMSProviderSetter) Set(value string) error {
 	smsProvider := map[string][]providerDetails{}
 	pairs := strings.Split(value, ";")
 	for _, pair := range pairs {
@@ -218,12 +218,12 @@ func (sd *SMSProviderDecoder) Decode(value string) error {
 		smsProvider[kvpair[0]] = providerdata
 
 	}
-	*sd = SMSProviderDecoder(smsProvider)
+	*sd = SMSProviderSetter(smsProvider)
 	return nil
 }
 
 type SMSProviderConfig struct {
-    ProviderWithWeight SMSProviderDecoder `envconfig:"SMS_PROVIDER_WITH_WEIGHT"`
+    ProviderWithWeight SMSProviderSetter `envconfig:"SMS_PROVIDER_WITH_WEIGHT"`
 }
 ```
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -19,8 +19,10 @@ import (
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
 var ErrInvalidSpecification = errors.New("specification must be a struct pointer")
 
-var gatherRegexp = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
-var acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
+var (
+	gatherRegexp  = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
+	acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
+)
 
 // A ParseError occurs when an environment variable cannot be converted to
 // the type required by a struct field during assignment.
@@ -33,7 +35,10 @@ type ParseError struct {
 }
 
 // Decoder has the same semantics as Setter, but takes higher precedence.
+//
 // It is provided for historical compatibility.
+//
+// Deprecated: use Setter.
 type Decoder interface {
 	Decode(value string) error
 }


### PR DESCRIPTION
Since godoc has hinted at the prefered usage of Setter, this change
removes examples using Decoder, and deprecates the symbol so that
linters will push customers to migrate.