### PR TITLE
Respec envconfig tag within usage

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -125,7 +125,13 @@ func Usagef(prefix string, spec interface{}, out io.Writer, format string) error
 
 	// Specify the default usage template functions
 	functions := template.FuncMap{
-		"usage_key":         func(v varInfo) string { return v.Key },
+		"usage_key": func(v varInfo) string {
+			val := v.Tags.Get("envconfig")
+			if val != "" {
+				return strings.ToUpper(val)
+			}
+			return v.Key
+		},
 		"usage_description": func(v varInfo) string { return v.Tags.Get("desc") },
 		"usage_type":        func(v varInfo) string { return toTypeDescription(v.Field.Type()) },
 		"usage_default":     func(v varInfo) string { return v.Tags.Get("default") },


### PR DESCRIPTION
This should potentially fix https://github.com/kelseyhightower/envconfig/issues/90, but currently the tests are failing because I haven't touched them so far. Before I fix the tests I wanted to clarify the rules. 

Currently the usage functionality is entirely ignoring the custom environment keys, with my approach it's first checking if the `envconfig:""` tag is set, if it is, it will just use it. I'm also transforing the tag value to uppercase as the variables seem to be uppercase all the time?

Another part that is not entirely clear to me, should the `envconfig:` tag ignore the prefix? AFAIK it does, but please make that clear to me :)