### PR TITLE
Support unexported fields

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 )
 
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
@@ -73,7 +74,7 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 	// over allocate an info array, we will extend if needed later
 	infos := make([]varInfo, 0, s.NumField())
 	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i)
+		f :=  reflect.NewAt(s.Field(i).Type(), unsafe.Pointer(s.Field(i).UnsafeAddr())).Elem()
 		ftype := typeOfSpec.Field(i)
 		if !f.CanSet() || isTrue(ftype.Tag.Get("ignored")) {
 			continue

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -792,6 +792,35 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 	}
 }
 
+func TestUnexportedField(t *testing.T) {
+	os.Clearenv()
+
+	_ = os.Setenv("ENV_CONFIG_FOO", "foo")
+	_ = os.Setenv("ENV_CONFIG_BAR", "100")
+	_ = os.Setenv("ENV_CONFIG_BAZ", "5,10,15")
+
+	type unexported struct {
+		foo string  `envconfig:"ENV_CONFIG_FOO"`
+		bar float64 `envconfig:"ENV_CONFIG_BAR"`
+		baz []int `envconfig:"ENV_CONFIG_BAZ"`
+	}
+
+	s := unexported{}
+	err := Process("env_config", &s)
+	if err != nil {
+		t.Error("error when parsing unexported fields")
+	}
+	if s.foo != "foo" {
+		t.Error("unexported string")
+	}
+	if s.bar != 100 {
+		t.Error("unexported int")
+	}
+	if s.baz[0] != 5 && s.baz[1] != 10 && s.baz[2] != 15 {
+		t.Error("unexported slice of ints")
+	}
+}
+
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
 		Foo    string `envconfig:"BAR" required:"true"`


### PR DESCRIPTION
I decided to extend the functionality to support unexported fields.
I have one main reason for this.
 - After I load a structure from envvars, I want to perform the steps that further create the state.  I load several variables and then calculate a new one from them, but there is no reason to have the originals public. Another example is that I parse the value of an enum from a private string variable. etc...
 ```go
// ENV_LOG_LEVEL=info
// my.strLogLevel is unexported and loaded from ENV_LOG_LEVEL
// exported my.LogLevel is NOT string and calculated from unexported one
 my.LogLevel = parseLogLevel(my.strLogLevel) 
```
Signed-off-by: kuritka <kuritka@gmail.com>