### PR TITLE
Improve error for required env vars with alt name

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -203,11 +203,7 @@ func Process(prefix string, spec interface{}) error {
 		req := info.Tags.Get("required")
 		if !ok && def == "" {
 			if isTrue(req) {
-				key := info.Key
-				if info.Alt != "" {
-					key = info.Alt
-				}
-				return fmt.Errorf("required key %s missing value", key)
+				return fmt.Errorf("required key %s missing value", info.Key)
 			}
 			continue
 		}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -794,7 +794,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()
@@ -804,8 +804,8 @@ func TestErrorMessageForRequiredAltVar(t *testing.T) {
 		t.Error("no failure when missing required variable")
 	}
 
-	if !strings.Contains(err.Error(), " BAR ") {
-		t.Errorf("expected error message to contain BAR, got \"%v\"", err)
+	if !strings.Contains(err.Error(), " ENV_CONFIG_BAR ") {
+		t.Errorf("expected error message to contain ENV_CONFIG_BAR, got \"%v\"", err)
 	}
 }
 


### PR DESCRIPTION
If we have a prefix called "env_config" and the following struct tags
for property "Foo", we should expect to see an error message stating
that the required env var "ENV_CONFIG_BAR" is missing and not just
"BAR" since that is the env var being looked up.

```
type Spec struct {
  Foo string `envconfig:"bar" required:"true"`
}
```

Fixes https://github.com/kelseyhightower/envconfig/issues/199