### PR TITLE
Unnecessary initialization of struct pointers fix

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -241,13 +241,20 @@ func removeEmptyStructs(spec interface{}) error {
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
 
-		if f.Kind() == reflect.Ptr && f.Elem().Kind() == reflect.Struct && !f.IsNil() {
-			if err := removeEmptyStructs(f.Elem().Addr().Interface()); err != nil {
+		switch f.Kind() {
+		case reflect.Struct:
+			if err := removeEmptyStructs(f.Addr().Interface()); err != nil {
 				return err
 			}
+		case reflect.Ptr:
+			if f.Elem().Kind() == reflect.Struct && !f.IsNil() {
+				if err := removeEmptyStructs(f.Elem().Addr().Interface()); err != nil {
+					return err
+				}
 
-			if f.Elem().IsZero() {
-				f.Set(reflect.Zero(f.Type()))
+				if f.Elem().IsZero() {
+					f.Set(reflect.Zero(f.Type()))
+				}
 			}
 		}
 	}

--- a/envconfig.go
+++ b/envconfig.go
@@ -245,6 +245,7 @@ func removeEmptyStructs(spec interface{}) error {
 			if !f.IsNil() {
 				if f.Elem().IsZero() {
 					f.Set(reflect.Zero(f.Type()))
+					continue
 				}
 			}
 

--- a/envconfig.go
+++ b/envconfig.go
@@ -241,19 +241,13 @@ func removeEmptyStructs(spec interface{}) error {
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
 
-		if f.Kind() == reflect.Ptr {
-			if !f.IsNil() {
-				if f.Elem().IsZero() {
-					f.Set(reflect.Zero(f.Type()))
-					continue
-				}
+		if f.Kind() == reflect.Ptr && f.Elem().Kind() == reflect.Struct && !f.IsNil() {
+			if err := removeEmptyStructs(f.Elem().Addr().Interface()); err != nil {
+				return err
 			}
 
-			if f.Elem().Kind() == reflect.Struct {
-				err := removeEmptyStructs(f.Elem().Addr().Interface())
-				if err != nil {
-					return err
-				}
+			if f.Elem().IsZero() {
+				f.Set(reflect.Zero(f.Type()))
 			}
 		}
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tj/assert"
 )
 
 type HonorDecodeInStruct struct {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -876,13 +876,25 @@ func Test_removeEmptyStructs(t *testing.T) {
 	type t1 struct {
 		Field1 *t2
 	}
-	t.Run("remove_empty_struct", func(t *testing.T) {
 
+	type t4 struct {
+		Field4 t1
+	}
+
+	t.Run("remove_empty_struct_all_pointers", func(t *testing.T) {
 		v := t1{Field1: &t2{Field2: &t3{}}}
 
 		err := removeEmptyStructs(&v)
 		require.NoError(t, err)
 		assert.Equal(t, t1{}, v)
+	})
+
+	t.Run("remove_empty_struct_non_pointer_level", func(t *testing.T) {
+		v := t4{Field4: t1{Field1: &t2{Field2: &t3{}}}}
+
+		err := removeEmptyStructs(&v)
+		require.NoError(t, err)
+		assert.Equal(t, t4{}, v)
 	})
 
 	t.Run("dont_remove_nonempty_struct", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/kelseyhightower/envconfig
+module github.com/hexdigest/envconfig

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,8 @@
 module github.com/hexdigest/envconfig
+
+go 1.16
+
+require (
+	github.com/stretchr/testify v1.7.0
+	github.com/tj/assert v0.0.3
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/hexdigest/envconfig
+module github.com/kelseyhightower/envconfig
 
 go 1.16
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/tj/assert v0.0.3
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
-github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Here is the correct version of the removeEmptyStructs mentioned in #113  that support multiple levels of structs nesting when some levels can be pointers and some not:

https://github.com/hexdigest/envconfig/blob/master/envconfig.go#L230:L263

I also added tests for this func.
Hope it helps to everyone who struggle from the same issue.

@kelseyhightower not quite sure that point_up thing can be a good candidate for a PR because it's more of a cleanup rather than an actual fix for the env parser even though I don't see how it can break something.