### PR TITLE
MustProcessT: return the typed spec

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -227,11 +227,17 @@ func Process(prefix string, spec interface{}) error {
 	return err
 }
 
-// MustProcess is the same as Process but panics if an error occurs
+// MustProcess is the same as Process but panics if an error occurs, and returns the spec.
 func MustProcess(prefix string, spec interface{}) {
 	if err := Process(prefix, spec); err != nil {
 		panic(err)
 	}
+}
+
+// MustProcessT is the same as MustProcess but returns the spec.
+func MustProcessT[T any](prefix string, spec T) T {
+	MustProcess(prefix, spec)
+	return spec
 }
 
 func processField(value string, field reflect.Value) error {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -519,6 +519,15 @@ func TestMustProcess(t *testing.T) {
 	MustProcess("env_config", &m)
 }
 
+func TestMustProcessT(t *testing.T) {
+	t.Setenv("ENV_CONFIG_REQUIREDVAR", "this is required")
+	s := MustProcessT("env_config", &Specification{})
+
+	if s.RequiredVar != "this is required" {
+		t.Errorf("expected %s, got %s", "foo", s.RequiredVar)
+	}
+}
+
 func TestEmbeddedStruct(t *testing.T) {
 	var s Specification
 	os.Clearenv()

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/kelseyhightower/envconfig
+
+go 1.22


### PR DESCRIPTION
This adds a generic `MustProcessT` method, that panics if processing fails, and returns the spec value.

Example usage:

```
package main

import (
  "log"

  "github.com/kelseyhightower/envconfig"
)

env := envconfig.MustProcessT("", &struct{
  Foo string `envconfig:"FOO" required:"true"`
}{})

func main() {
  log.Println("your FOO is " + env.Foo)
}
```

This lets the env struct be moved to an init-time var, out of `func main`, and retains all the env parsing behavior we've all come to know and love.

The structure of that var statement is kind of gross (inline-defining a struct and its empty value, and passing it to the method), if I'm missing some way to make it better, let me know.

Type parameters were required, since `MustProcessT(string, interface{}) interface{}` loses information about the input type. You could cast back to the type you want, but generics are better IMO, since it lets you do it all in one statement.

This change requires `go.mod` to state the version of Go that's needed. Otherwise, `go build` defaults to an old version, which doesn't have type parameters:

```
go build ./...
# github.com/kelseyhightower/envconfig
./envconfig.go:238:19: type parameter requires go1.18 or later (-lang was set to go1.16; check go.mod)
./envconfig.go:238:21: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
```

I chose the latest Go, but if you think it should be 1.18 I'm fine with that too.