### PR TITLE
feat: have a full key when missing config

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -203,11 +203,7 @@ func Process(prefix string, spec interface{}) error {
 		req := info.Tags.Get("required")
 		if !ok && def == "" {
 			if isTrue(req) {
-				key := info.Key
-				if info.Alt != "" {
-					key = info.Alt
-				}
-				return fmt.Errorf("required key %s missing value", key)
+				return fmt.Errorf("required key %s missing value", info.Key)
 			}
 			continue
 		}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -804,8 +804,27 @@ func TestErrorMessageForRequiredAltVar(t *testing.T) {
 		t.Error("no failure when missing required variable")
 	}
 
-	if !strings.Contains(err.Error(), " BAR ") {
-		t.Errorf("expected error message to contain BAR, got \"%v\"", err)
+	if !strings.Contains(err.Error(), " ENV_CONFIG_BAR ") {
+		t.Errorf("expected error message to contain ENV_CONFIG_BAR, got \"%v\"", err)
+	}
+}
+
+func TestErrorMessageForRequiredAltVarWithKey(t *testing.T) {
+	var s struct {
+		Bar struct {
+			Foo string `envconfig:"FOO" required:"true"`
+		} `envconfig:"BAR"`
+	}
+
+	os.Clearenv()
+	err := Process("env_config", &s)
+
+	if err == nil {
+		t.Error("no failure when missing required variable")
+	}
+
+	if !strings.Contains(err.Error(), " ENV_CONFIG_BAR_FOO ") {
+		t.Errorf("expected error message to contain ENV_CONFIG_BAR_FOO, got \"%v\"", err)
 	}
 }
 


### PR DESCRIPTION
This PR makes the error better when returned on a missing configuration.

For example, if you have a config like this:

```go

var config struct {
	Bar struct {
		Foo string `envconfig:"FOO" required:"true"`
	} `envconfig:"BAR"`
}
```

The error goes from
```
required key FOO missing value
```

To:
```
required key ENV_CONFIG_BAR_FOO missing value
```

Thanks again for your project(s) !
