### PR TITLE
Add support for fields with Set(value T).

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,7 @@ type SMSProviderConfig struct {
 
 Also, envconfig will use a `Set(string) error` method like from the
 [flag.Value](https://godoc.org/flag#Value) interface if implemented.
+
+If a field implements a method like `Set(value T)`, envconfig will attempt to decode
+into a new `T` using any of the above mechanisms and then call `Set`.
+See [envconfig_1.18_test.go](envconfig_1.18_test.go) for examples.

--- a/envconfig.go
+++ b/envconfig.go
@@ -129,7 +129,7 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 
 		if f.Kind() == reflect.Struct {
 			// honor Decode if present
-			if decoderFrom(f) == nil && setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
+			if decoderFrom(f) == nil && setterFrom(f) == nil && genericSetterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
 				innerPrefix := prefix
 				if !ftype.Anonymous {
 					innerPrefix = info.Key
@@ -255,6 +255,10 @@ func processField(value string, field reflect.Value) error {
 		return b.UnmarshalBinary([]byte(value))
 	}
 
+	if generic := genericSetterFrom(field); generic != nil {
+		return generic.DecodeAndSet(value)
+	}
+
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 		if field.IsNil() {
@@ -353,6 +357,40 @@ func interfaceFrom(field reflect.Value, fn func(interface{}, *bool)) {
 	fn(field.Interface(), &ok)
 	if !ok && field.CanAddr() {
 		fn(field.Addr().Interface(), &ok)
+	}
+}
+
+// genericSetter handles fields with a method like Set(value T) by decoding into a new T and then calling Set.
+type genericSetter struct {
+	parameter reflect.Value
+	doSet     func()
+}
+
+func (g *genericSetter) DecodeAndSet(value string) error {
+	err := processField(value, g.parameter)
+	if err != nil {
+		return err
+	}
+	g.doSet()
+	return nil
+}
+
+func genericSetterFrom(field reflect.Value) *genericSetter {
+	if !field.CanAddr() {
+		return nil
+	}
+	fieldPtr := field.Addr()
+	method, ok := fieldPtr.Type().MethodByName("Set")
+	// Check for signature Set(value T) with concrete type T. The receiver is the first In, the parameter second.
+	if !ok || method.Type.NumIn() != 2 || method.Type.NumOut() != 0 || method.Type.In(1).Kind() == reflect.Interface {
+		return nil
+	}
+	parameter := reflect.New(method.Type.In(1)).Elem()
+	return &genericSetter{
+		parameter: parameter,
+		doSet: func() {
+			method.Func.Call([]reflect.Value{fieldPtr, parameter})
+		},
 	}
 }
 

--- a/envconfig_1.18_test.go
+++ b/envconfig_1.18_test.go
@@ -1,0 +1,101 @@
+//go:build go1.18
+// +build go1.18
+
+package envconfig
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// A GenericSetter has a Set method accepting an already-decoded value of type T.
+//
+// The GenericSetter interface is not defined outside of this go1.18-gated test file because:
+// - Generics are not available until go1.18, and this library currently supports much older code.
+// - It is not useful in Process - we cannot type-assert GenericSetter[T] without knowing T at compile time.
+type GenericSetter[T any] interface {
+	// Set accepts an already-decoded value T.
+	//
+	// The value should handle its own decoding via any envconfig-supported mechanism.
+	// Because value should be fully decoded, there is no error return on this method, unlike the flag-compatible
+	// Set method accepting a string.
+	Set(value T)
+}
+
+type Box[T any] struct {
+	Value T
+}
+
+func (b *Box[T]) Set(value T) {
+	b.Value = value
+}
+
+// A Box is an example of a GenericSetter.
+var _ GenericSetter[int] = (*Box[int])(nil)
+
+type StringBox struct {
+	Value string
+}
+
+func (b *StringBox) Set(value string) {
+	b.Value = value
+}
+
+// Though not generic, StringBox implements GenericSetter[string].
+//
+// We support non-generic wrapper types with a Set method.
+var _ GenericSetter[string] = (*StringBox)(nil)
+
+type SpecWithGenericSetters struct {
+	IntBox       Box[int]
+	IntBoxPtr    *Box[int]
+	IntPtrBox    Box[*int]
+	IntPtrBoxPtr *Box[*int]
+	MapBox       Box[map[string]time.Duration]
+	StringBox    StringBox
+}
+
+func TestProcess_GenericSetter(t *testing.T) {
+	var s SpecWithGenericSetters
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_INTBOX", "1")
+	os.Setenv("ENV_CONFIG_INTBOXPTR", "2")
+	os.Setenv("ENV_CONFIG_INTPTRBOX", "3")
+	os.Setenv("ENV_CONFIG_INTPTRBOXPTR", "4")
+	os.Setenv("ENV_CONFIG_MAPBOX", "short:1s,medium:2s,long:3s")
+	os.Setenv("ENV_CONFIG_STRINGBOX", "mystring")
+	err := Process("env_config", &s)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if s.IntBox.Value != 1 {
+		t.Errorf("expected %v, got %v", "1", s.IntBox.Value)
+	}
+	if s.IntBoxPtr.Value != 2 {
+		t.Errorf("expected %v, got %v", "2", s.IntBoxPtr.Value)
+	}
+	if *s.IntPtrBox.Value != 3 {
+		t.Errorf("expected %v, got %v", "3", s.IntPtrBox.Value)
+	}
+	if *s.IntPtrBoxPtr.Value != 4 {
+		t.Errorf("expected %v, got %v", "4", s.IntPtrBoxPtr.Value)
+	}
+	if len(s.MapBox.Value) != 3 ||
+		s.MapBox.Value["short"] != 1*time.Second ||
+		s.MapBox.Value["medium"] != 2*time.Second ||
+		s.MapBox.Value["long"] != 3*time.Second {
+		t.Errorf(
+			"expected %#v, got %#v",
+			map[string]time.Duration{
+				"short":  1 * time.Second,
+				"medium": 2 * time.Second,
+				"long":   3 * time.Second,
+			},
+			s.MapBox.Value,
+		)
+	}
+	if s.StringBox.Value != "mystring" {
+		t.Errorf("expected %v, got %v", "mystring", s.StringBox.Value)
+	}
+}


### PR DESCRIPTION
This is most useful for generic "wrapper" types that add behavior to a contained value.

These kinds of wrappers can be useful for configuration values:
- A wrapper for sensitive values with protections against printing or logging.
- A wrapper integrating with a scheme for dynamic configuration changes.

The desirable behavior for a wrapper containing a value of type T is for the envconfig facilities to apply for decoding the contained value. Achieving this behavior today requires duplicating much of the logic in `processField` in a custom `Decode` method on the wrapper, in order to handle all the various types of values that might be contained.

Instead, this commit introduces support for arbitrary Set(value T) methods by first decoding into a new T and then calling the Set method.